### PR TITLE
Change contract return types

### DIFF
--- a/spawnable-contract/schema1/MeetupContract.xml
+++ b/spawnable-contract/schema1/MeetupContract.xml
@@ -839,19 +839,19 @@ bFTFAiBKJSQRqq66kI9yMPc1NJISGi8btpWfPiB78twtjuHe7A==
         <function>isExpired</function>
       </origin>
     </attribute-type>
-    <attribute-type id="street" syntax="1.3.6.1.4.1.1466.115.121.1.7">
+    <attribute-type id="street" syntax="1.3.6.1.4.1.1466.115.121.1.26">
       <origin contract="holding-contract">
         <function>getStreet</function>
         <parameter>TokenID</parameter><!-- place holder - actual format undefined yet -->
       </origin>
     </attribute-type>
-    <attribute-type id="building" syntax="1.3.6.1.4.1.1466.115.121.1.7">
+    <attribute-type id="building" syntax="1.3.6.1.4.1.1466.115.121.1.26">
       <origin contract="holding-contract">
         <function>getBuildingName</function>
         <parameter>TokenID</parameter><!-- place holder - actual format undefined yet -->
       </origin>
     </attribute-type>
-    <attribute-type id="state" syntax="1.3.6.1.4.1.1466.115.121.1.7">
+    <attribute-type id="state" syntax="1.3.6.1.4.1.1466.115.121.1.26">
       <origin contract="holding-contract">
         <function>getState</function>
         <parameter>TokenID</parameter><!-- place holder - actual format undefined yet -->


### PR DESCRIPTION
Contract function specs for:

- getStreet
- getBuildingName
- getState

were set up to receive a boolean type (1.3.6.1.4.1.1466.115.121.1.7). Now they're set to receive an IA5String type (1.3.6.1.4.1.1466.115.121.1.26) as expected.