### PR TITLE
make xml uniform for the release + add <mapping>

### DIFF
--- a/blockchain-tickets/schema1/TicketingContract.xml
+++ b/blockchain-tickets/schema1/TicketingContract.xml
@@ -167,7 +167,7 @@
       <t:name lang="zh">城市</t:name>
       <t:name lang="es">Ciudad</t:name>
       <t:name lang="ru">город</t:name>
-      <t:origin as="mapping" bitmask="00000000000000000000000000000000FF000000000000000000000000000000">
+      <t:origin bitmask="00000000000000000000000000000000FF000000000000000000000000000000" as="mapping">
         <t:option key="1">
           <t:value lang="ru">Москва́</t:value>
           <t:value lang="en">Moscow</t:value>
@@ -341,7 +341,7 @@
       <t:name lang="zh">场馆</t:name>
       <t:name lang="es">Lugar</t:name>
       <t:name lang="ru">место встречи</t:name>
-      <t:origin as="mapping" bitmask="0000000000000000000000000000000000FF0000000000000000000000000000">
+      <t:origin bitmask="0000000000000000000000000000000000FF0000000000000000000000000000" as="mapping">
         <t:option key="1">
           <t:value lang="ru">Стадион Калининград</t:value>
           <t:value lang="en">Kaliningrad Stadium</t:value>
@@ -493,7 +493,7 @@
       <t:name lang="ru">время</t:name>
       <!-- keys used here are BinaryTime (RFC6019) for backward compatibility,
            don't copy this behaviour when creating new assets -->
-      <t:origin as="mapping" bitmask="000000000000000000000000000000000000FFFFFFFF00000000000000000000">
+      <t:origin bitmask="000000000000000000000000000000000000FFFFFFFF00000000000000000000" as="mapping">
 	<!-- Shanghai -->
         <t:option key="1531576800">
           <t:value>20180714170000+0300</t:value>
@@ -512,25 +512,25 @@
       <t:name lang="en">Team A</t:name>
       <t:name lang="zh">甲队</t:name>
       <t:name lang="es">Equipo A</t:name>
-      <t:origin as="utf8" bitmask="00000000000000000000000000000000000000000000FFFFFF00000000000000"/>
+      <t:origin bitmask="00000000000000000000000000000000000000000000FFFFFF00000000000000" as="utf8"/>
     </t:attribute-type>
     <t:attribute-type id="countryB" syntax="1.3.6.1.4.1.1466.115.121.1.26">
       <t:name lang="en">Team B</t:name>
       <t:name lang="zh">乙队</t:name>
       <t:name lang="es">Equipo B</t:name>
-      <t:origin as="utf8" bitmask="00000000000000000000000000000000000000000000000000FFFFFF00000000"/>
+      <t:origin bitmask="00000000000000000000000000000000000000000000000000FFFFFF00000000" as="utf8"/>
     </t:attribute-type>
     <t:attribute-type id="match" syntax="1.3.6.1.4.1.1466.115.121.1.27">
       <t:name lang="en">Match</t:name>
       <t:name lang="zh">场次</t:name>
       <t:name lang="es">Evento</t:name>
-      <t:origin as="unsigned" bitmask="00000000000000000000000000000000000000000000000000000000FF000000"/>
+      <t:origin bitmask="00000000000000000000000000000000000000000000000000000000FF000000" as="unsigned"/>
     </t:attribute-type>
     <t:attribute-type id="category" syntax="1.3.6.1.4.1.1466.115.121.1.15">
       <t:name lang="en">Cat</t:name>
       <t:name lang="zh">等级</t:name>
       <t:name lang="es">Cat</t:name>
-      <t:origin as="mapping" bitmask="0000000000000000000000000000000000000000000000000000000000FF0000">
+      <t:origin bitmask="0000000000000000000000000000000000000000000000000000000000FF0000" as="mapping">
         <t:option key="1">
           <t:value lang="en">Category 1</t:value>
           <t:value lang="zh">一类票</t:value>
@@ -667,7 +667,7 @@
     </t:attribute-type>
     <t:attribute-type id="numero" syntax="1.3.6.1.4.1.1466.115.121.1.27">
       <t:name>№</t:name>
-      <t:origin as="unsigned" bitmask="000000000000000000000000000000000000000000000000000000000000FFFF"/>
+      <t:origin bitmask="000000000000000000000000000000000000000000000000000000000000FFFF" as="unsigned"/>
     </t:attribute-type>
   </t:attribute-types>
 </t:token>

--- a/blockchain-tickets/schema1/TicketingContract.xml
+++ b/blockchain-tickets/schema1/TicketingContract.xml
@@ -168,172 +168,174 @@
       <t:name lang="es">Ciudad</t:name>
       <t:name lang="ru">город</t:name>
       <t:origin bitmask="00000000000000000000000000000000FF000000000000000000000000000000" as="mapping">
-        <t:option key="1">
-          <t:value lang="ru">Москва́</t:value>
-          <t:value lang="en">Moscow</t:value>
-          <t:value lang="zh">莫斯科</t:value>
-          <t:value lang="es">Moscú</t:value>
-        </t:option>
-        <t:option key="2">
-          <t:value lang="ru">Санкт-Петербу́рг</t:value>
-          <t:value lang="en">Saint Petersburg</t:value>
-          <t:value lang="zh">圣彼得堡</t:value>
-          <t:value lang="es">San Petersburgo</t:value>
-        </t:option>
-        <t:option key="3">
-          <t:value lang="ru">сочи</t:value>
-          <t:value lang="en">Sochi</t:value>
-          <t:value lang="zh">索契</t:value>
-          <t:value lang="es">Sochi</t:value>
-        </t:option>
-        <t:option key="4">
-          <t:value lang="ru">екатеринбург</t:value>
-          <t:value lang="en">Ekaterinburg</t:value>
-          <t:value lang="zh">叶卡捷琳堡</t:value>
-          <t:value lang="es">Ekaterinburg</t:value>
-        </t:option>
-        <t:option key="5">
-          <t:value lang="ru">Саранск</t:value>
-          <t:value lang="en">Saransk</t:value>
-          <t:value lang="zh">萨兰斯克</t:value>
-          <t:value lang="es">Saransk</t:value>
-        </t:option>
-        <t:option key="6">
-          <t:value lang="ru">казань</t:value>
-          <t:value lang="en">Kazan</t:value>
-          <t:value lang="zh">喀山</t:value>
-          <t:value lang="es">Kazan</t:value>
-        </t:option>
-        <t:option key="7">
-          <t:value lang="ru">Нижний Новгород</t:value>
-          <t:value lang="en">Nizhny Novgorod</t:value>
-          <t:value lang="zh">下诺夫哥罗德</t:value>
-          <t:value lang="es">Nizhny Novgorod</t:value>
-        </t:option>
-        <t:option key="8">
-          <t:value lang="ru">Ростов-на-Дону</t:value>
-          <t:value lang="en">Rostov-on-Don</t:value>
-          <t:value lang="zh">顿河畔罗斯托夫</t:value>
-          <t:value lang="es">Rostov-on-Don</t:value>
-        </t:option>
-        <t:option key="9">
-          <t:value lang="ru">Самара</t:value>
-          <t:value lang="en">Samara</t:value>
-          <t:value lang="zh">萨马拉</t:value>
-          <t:value lang="es">Samara</t:value>
-        </t:option>
-        <t:option key="10">
-          <t:value lang="ru">Волгоград</t:value>
-          <t:value lang="en">Volgograd</t:value>
-          <t:value lang="zh">伏尔加格勒</t:value>
-          <t:value lang="es">Volgogrado</t:value>
-        </t:option>
-        <t:option key="11">
-          <t:value lang="ru">Калининград</t:value>
-          <t:value lang="en">Kaliningrad</t:value>
-          <t:value lang="zh">加里宁格勒</t:value>
-          <t:value lang="es">Kaliningrad</t:value>
-        </t:option>
-        <t:option key="255">
-          <t:value lang="ru">Сидней</t:value>
-          <t:value lang="en">Sydney</t:value>
-          <t:value lang="zh">悉尼</t:value>
-          <t:value lang="es">Sídney</t:value>
-        </t:option>
-        <t:option key="254">
-          <t:value lang="ru">Сингапур</t:value>
-          <t:value lang="en">Singapore</t:value>
-          <t:value lang="zh">新加坡</t:value>
-          <t:value lang="es">Singapur</t:value>
-        </t:option>
-        <t:option key="253">
-          <t:value lang="zh">深圳</t:value>
-          <t:value lang="en">Shenzhen</t:value>
-        </t:option>
-        <t:option key="252">
-          <t:value lang="zh">北京</t:value>
-          <t:value lang="en">Beijing</t:value>
-        </t:option>
-        <t:option key="251">
-          <t:value lang="zh">上海</t:value>
-          <t:value lang="en">Shanghai</t:value>
-        </t:option>
-        <t:option key="250">
-          <t:value lang="en">Tokyo</t:value>
-          <t:value lang="zh">东京</t:value>
-        </t:option>
-        <t:option key="249">
-          <t:value lang="en">Seoul</t:value>
-          <t:value lang="zh">首尔</t:value>
-        </t:option>
-        <t:option key="248">
-          <t:value lang="zh">重庆</t:value>
-          <t:value lang="en">Chongqing</t:value>
-        </t:option>
-        <t:option key="247">
-          <t:value lang="en">New York</t:value>
-          <t:value lang="zh">纽约</t:value>
-        </t:option>
-        <t:option key="246">
-          <t:value lang="en">Melbourne</t:value>
-          <t:value lang="zh">墨尔本</t:value>
-        </t:option>
-        <t:option key="245">
-          <t:value lang="en">Hong Kong</t:value>
-          <t:value lang="zh">香港</t:value>
-        </t:option>
-        <t:option key="244">
-          <t:value lang="zh">成都</t:value>
-          <t:value lang="en">Chengdu</t:value>
-        </t:option>
-        <t:option key="243">
-          <t:value lang="en">Kuala Lumpur</t:value>
-          <t:value lang="zh">吉隆坡</t:value>
-        </t:option>
-        <t:option key="242">
-          <t:value lang="en">Bangkok</t:value>
-          <t:value lang="zh">曼谷</t:value>
-        </t:option>
-        <t:option key="241">
-          <t:value lang="en">San Francisco</t:value>
-          <t:value lang="zh">三藩市</t:value>
-        </t:option>
-        <t:option key="240">
-          <t:value lang="en">Las Vegas</t:value>
-          <t:value lang="zh">拉斯维加斯</t:value>
-        </t:option>
-        <t:option key="239">
-          <t:value lang="en">London</t:value>
-          <t:value lang="zh">伦敦</t:value>
-        </t:option>
-        <t:option key="238">
-          <t:value lang="en">Barcelona</t:value>
-          <t:value lang="zh">巴塞罗那</t:value>
-        </t:option>
-        <t:option key="237">
-          <t:value lang="en">Madrid</t:value>
-          <t:value lang="zh">马德里</t:value>
-        </t:option>
-        <t:option key="236">
-          <t:value lang="en">Zug</t:value>
-          <t:value lang="zh">楚格</t:value>
-        </t:option>
-        <t:option key="235">
-          <t:value lang="en">Paris</t:value>
-          <t:value lang="zh">巴黎</t:value>
-        </t:option>
-        <t:option key="234">
-          <t:value lang="en">Dubai</t:value>
-          <t:value lang="zh">迪拜</t:value>
-        </t:option>
-        <t:option key="233">
-          <t:value lang="en">TBC</t:value>
-          <t:value lang="zh">待定</t:value>
-        </t:option>
-         <t:option key="232">
-          <t:value lang="en">Exhibition stand A311</t:value>
-          <t:value lang="zh">展台A311</t:value>
-        </t:option>
+        <t:mapping>
+          <t:option key="1">
+            <t:value lang="ru">Москва́</t:value>
+            <t:value lang="en">Moscow</t:value>
+            <t:value lang="zh">莫斯科</t:value>
+            <t:value lang="es">Moscú</t:value>
+          </t:option>
+          <t:option key="2">
+            <t:value lang="ru">Санкт-Петербу́рг</t:value>
+            <t:value lang="en">Saint Petersburg</t:value>
+            <t:value lang="zh">圣彼得堡</t:value>
+            <t:value lang="es">San Petersburgo</t:value>
+          </t:option>
+          <t:option key="3">
+            <t:value lang="ru">сочи</t:value>
+            <t:value lang="en">Sochi</t:value>
+            <t:value lang="zh">索契</t:value>
+            <t:value lang="es">Sochi</t:value>
+          </t:option>
+          <t:option key="4">
+            <t:value lang="ru">екатеринбург</t:value>
+            <t:value lang="en">Ekaterinburg</t:value>
+            <t:value lang="zh">叶卡捷琳堡</t:value>
+            <t:value lang="es">Ekaterinburg</t:value>
+          </t:option>
+          <t:option key="5">
+            <t:value lang="ru">Саранск</t:value>
+            <t:value lang="en">Saransk</t:value>
+            <t:value lang="zh">萨兰斯克</t:value>
+            <t:value lang="es">Saransk</t:value>
+          </t:option>
+          <t:option key="6">
+            <t:value lang="ru">казань</t:value>
+            <t:value lang="en">Kazan</t:value>
+            <t:value lang="zh">喀山</t:value>
+            <t:value lang="es">Kazan</t:value>
+          </t:option>
+          <t:option key="7">
+            <t:value lang="ru">Нижний Новгород</t:value>
+            <t:value lang="en">Nizhny Novgorod</t:value>
+            <t:value lang="zh">下诺夫哥罗德</t:value>
+            <t:value lang="es">Nizhny Novgorod</t:value>
+          </t:option>
+          <t:option key="8">
+            <t:value lang="ru">Ростов-на-Дону</t:value>
+            <t:value lang="en">Rostov-on-Don</t:value>
+            <t:value lang="zh">顿河畔罗斯托夫</t:value>
+            <t:value lang="es">Rostov-on-Don</t:value>
+          </t:option>
+          <t:option key="9">
+            <t:value lang="ru">Самара</t:value>
+            <t:value lang="en">Samara</t:value>
+            <t:value lang="zh">萨马拉</t:value>
+            <t:value lang="es">Samara</t:value>
+          </t:option>
+          <t:option key="10">
+            <t:value lang="ru">Волгоград</t:value>
+            <t:value lang="en">Volgograd</t:value>
+            <t:value lang="zh">伏尔加格勒</t:value>
+            <t:value lang="es">Volgogrado</t:value>
+          </t:option>
+          <t:option key="11">
+            <t:value lang="ru">Калининград</t:value>
+            <t:value lang="en">Kaliningrad</t:value>
+            <t:value lang="zh">加里宁格勒</t:value>
+            <t:value lang="es">Kaliningrad</t:value>
+          </t:option>
+          <t:option key="255">
+            <t:value lang="ru">Сидней</t:value>
+            <t:value lang="en">Sydney</t:value>
+            <t:value lang="zh">悉尼</t:value>
+            <t:value lang="es">Sídney</t:value>
+          </t:option>
+          <t:option key="254">
+            <t:value lang="ru">Сингапур</t:value>
+            <t:value lang="en">Singapore</t:value>
+            <t:value lang="zh">新加坡</t:value>
+            <t:value lang="es">Singapur</t:value>
+          </t:option>
+          <t:option key="253">
+            <t:value lang="zh">深圳</t:value>
+            <t:value lang="en">Shenzhen</t:value>
+          </t:option>
+          <t:option key="252">
+            <t:value lang="zh">北京</t:value>
+            <t:value lang="en">Beijing</t:value>
+          </t:option>
+          <t:option key="251">
+            <t:value lang="zh">上海</t:value>
+            <t:value lang="en">Shanghai</t:value>
+          </t:option>
+          <t:option key="250">
+            <t:value lang="en">Tokyo</t:value>
+            <t:value lang="zh">东京</t:value>
+          </t:option>
+          <t:option key="249">
+            <t:value lang="en">Seoul</t:value>
+            <t:value lang="zh">首尔</t:value>
+          </t:option>
+          <t:option key="248">
+            <t:value lang="zh">重庆</t:value>
+            <t:value lang="en">Chongqing</t:value>
+          </t:option>
+          <t:option key="247">
+            <t:value lang="en">New York</t:value>
+            <t:value lang="zh">纽约</t:value>
+          </t:option>
+          <t:option key="246">
+            <t:value lang="en">Melbourne</t:value>
+            <t:value lang="zh">墨尔本</t:value>
+          </t:option>
+          <t:option key="245">
+            <t:value lang="en">Hong Kong</t:value>
+            <t:value lang="zh">香港</t:value>
+          </t:option>
+          <t:option key="244">
+            <t:value lang="zh">成都</t:value>
+            <t:value lang="en">Chengdu</t:value>
+          </t:option>
+          <t:option key="243">
+            <t:value lang="en">Kuala Lumpur</t:value>
+            <t:value lang="zh">吉隆坡</t:value>
+          </t:option>
+          <t:option key="242">
+            <t:value lang="en">Bangkok</t:value>
+            <t:value lang="zh">曼谷</t:value>
+          </t:option>
+          <t:option key="241">
+            <t:value lang="en">San Francisco</t:value>
+            <t:value lang="zh">三藩市</t:value>
+          </t:option>
+          <t:option key="240">
+            <t:value lang="en">Las Vegas</t:value>
+            <t:value lang="zh">拉斯维加斯</t:value>
+          </t:option>
+          <t:option key="239">
+            <t:value lang="en">London</t:value>
+            <t:value lang="zh">伦敦</t:value>
+          </t:option>
+          <t:option key="238">
+            <t:value lang="en">Barcelona</t:value>
+            <t:value lang="zh">巴塞罗那</t:value>
+          </t:option>
+          <t:option key="237">
+            <t:value lang="en">Madrid</t:value>
+            <t:value lang="zh">马德里</t:value>
+          </t:option>
+          <t:option key="236">
+            <t:value lang="en">Zug</t:value>
+            <t:value lang="zh">楚格</t:value>
+          </t:option>
+          <t:option key="235">
+            <t:value lang="en">Paris</t:value>
+            <t:value lang="zh">巴黎</t:value>
+          </t:option>
+          <t:option key="234">
+            <t:value lang="en">Dubai</t:value>
+            <t:value lang="zh">迪拜</t:value>
+          </t:option>
+          <t:option key="233">
+            <t:value lang="en">TBC</t:value>
+            <t:value lang="zh">待定</t:value>
+          </t:option>
+          <t:option key="232">
+            <t:value lang="en">Exhibition stand A311</t:value>
+            <t:value lang="zh">展台A311</t:value>
+          </t:option>
+        </t:mapping>
       </t:origin>
     </t:attribute-type>
     <t:attribute-type id="venue" syntax="1.3.6.1.4.1.1466.115.121.1.15">
@@ -342,148 +344,150 @@
       <t:name lang="es">Lugar</t:name>
       <t:name lang="ru">место встречи</t:name>
       <t:origin bitmask="0000000000000000000000000000000000FF0000000000000000000000000000" as="mapping">
-        <t:option key="1">
-          <t:value lang="ru">Стадион Калининград</t:value>
-          <t:value lang="en">Kaliningrad Stadium</t:value>
-          <t:value lang="zh">加里宁格勒体育场</t:value>
-          <t:value lang="es">Estadio de Kaliningrado</t:value>
-        </t:option>
-        <t:option key="2">
-          <t:value lang="ru">Екатеринбург Арена</t:value>
-          <t:value lang="en">Volgograd Arena</t:value>
-          <t:value lang="zh">伏尔加格勒体育场</t:value>
-          <t:value lang="es">Volgogrado Arena</t:value>
-        </t:option>
-        <t:option key="3">
-          <t:value lang="ru">Казань Арена</t:value>
-          <t:value lang="en">Ekaterinburg Arena</t:value>
-          <t:value lang="zh">加里宁格勒体育场</t:value>
-          <t:value lang="es">Ekaterimburgo Arena</t:value>
-        </t:option>
-        <t:option key="4">
-          <t:value lang="ru">Мордовия Арена</t:value>
-          <t:value lang="en">Fisht Stadium</t:value>
-          <t:value lang="zh">费什体育场</t:value>
-          <t:value lang="es">Estadio Fisht</t:value>
-        </t:option>
-        <t:option key="5">
-          <t:value lang="ru">Ростов Арена</t:value>
-          <t:value lang="en">Kazan Arena</t:value>
-          <t:value lang="zh">喀山体育场</t:value>
-          <t:value lang="es">Kazan Arena</t:value>
-        </t:option>
-        <t:option key="6">
-          <t:value lang="ru">Самара Арена</t:value>
-          <t:value lang="en">Nizhny Novgorod Stadium</t:value>
-          <t:value lang="zh">下诺夫哥罗德体育场</t:value>
-          <t:value lang="es">Estadio de Nizhni Novgorod</t:value>
-        </t:option>
-        <t:option key="7">
-          <t:value lang="ru">Стадион Калининград</t:value>
-          <t:value lang="en">Luzhniki Stadium</t:value>
-          <t:value lang="zh">卢日尼基体育场</t:value>
-          <t:value lang="es">Estadio Luzhniki</t:value>
-        </t:option>
-        <t:option key="8">
-          <t:value lang="ru">Стадион Лужники</t:value>
-          <t:value lang="en">Samara Arena</t:value>
-          <t:value lang="zh">萨马拉体育场</t:value>
-          <t:value lang="es">Samara Arena</t:value>
-        </t:option>
-        <t:option key="9">
-          <t:value lang="ru">Стадион Нижний Новгород</t:value>
-          <t:value lang="en">Rostov Arena</t:value>
-          <t:value lang="zh">罗斯托夫体育场</t:value>
-          <t:value lang="es">Rostov Arena</t:value>
-        </t:option>
-        <t:option key="10">
-          <t:value lang="ru">Стадион Спартак</t:value>
-          <t:value lang="en">Spartak Stadium</t:value>
-          <t:value lang="zh">斯巴达克体育场</t:value>
-          <t:value lang="es">Estadio del Spartak</t:value>
-        </t:option>
-        <t:option key="11">
-          <t:value lang="ru">Стадион Санкт-Петербург</t:value>
-          <t:value lang="en">Saint Petersburg Stadium</t:value>
-          <t:value lang="zh">圣彼得堡体育场</t:value>
-          <t:value lang="es">Estadio de San Petersburgo</t:value>
-        </t:option>
-        <t:option key="12">
-          <t:value lang="ru">Стадион Фишт</t:value>
-          <t:value lang="en">Mordovia Arena</t:value>
-          <t:value lang="zh">莫多维亚体育场</t:value>
-          <t:value lang="es">Mordovia Arena</t:value>
-        </t:option>
-        <t:option key="255">
-          <t:value lang="en">UNSW Michael Crouch Innovation Center</t:value>
-          <t:value lang="zh">新南威尔大学Michael Crouch创新中心</t:value>
-          <t:value lang="es">Centro de Innovación de Michael Crouch UNSW</t:value>
-        </t:option>
-        <t:option key="254">
-          <t:value lang="en">FOUR SEASONS HOTEL SHENZHEN</t:value>
-          <t:value lang="zh">深圳四季酒店</t:value>
-        </t:option>
-        <t:option key="253">
-          <t:value lang="en">Paypal Innovation Lab</t:value>
-        </t:option>
-        <t:option key="252">
-          <t:value lang="en">The Centrepoint</t:value>
-        </t:option>
-        <t:option key="251">
-          <t:value lang="en">TBC</t:value>
-          <t:value lang="zh">待定</t:value>
-        </t:option>
-        <t:option key="250">
-          <t:value>thebridge</t:value>
-        </t:option>
-        <t:option key="249">
-          <t:value>BASH</t:value>
-        </t:option>
-        <t:option key="248">
-          <t:value>Spacemob</t:value>
-        </t:option>
-        <t:option key="247">
-          <t:value lang="en">32 Carpenter Street</t:value>
-        </t:option>
-        <t:option key="246">
-          <t:value>Block 71</t:value>
-        </t:option>
-        <t:option key="245">
-          <t:value lang="en">Microsoft Singapore</t:value>
-          <t:value lang="zh">微软新加坡</t:value>
-        </t:option>
-        <t:option key="243">
-          <t:value lang="en">Google Singapore</t:value>
-        </t:option>
-        <t:option key="242">
-          <t:value lang="en">The Blockchain Hub</t:value>
-        </t:option>
-        <t:option key="241">
-          <t:value>BitTemple</t:value>
-        </t:option>
-        <t:option key="240">
-          <t:value lang="en">ADD BLOCKCHAIN STUDIO</t:value>
-        </t:option>
-        <t:option key="239">
-          <t:value lang="en">Rosewood Beijing</t:value>
-          <t:value lang="zh">北京瑰丽酒店</t:value>
-        </t:option>
-        <t:option key="238">
-          <t:value lang="en">Stratum</t:value>
-          <t:value lang="zh">臻宛</t:value>
-        </t:option>
-        <t:option key="237">
-          <t:value lang="en">Hong Kong Convention and Exhibition Centre</t:value>
-          <t:value lang="zh">香港会议展览中心</t:value>
-        </t:option>
-        <t:option key="236">
-          <t:value lang="en">P2联合创业办公社 中关村e世界</t:value>
-          <t:value lang="zh">P2联合创业办公社 中关村e世界</t:value>
-        </t:option>
-        <t:option key="235">
-          <t:value lang="en">Fortune coffee@The Bund</t:value>
-          <t:value lang="zh">泛合金融咖啡@上海外滩</t:value>
-        </t:option>
+        <t:mapping>
+          <t:option key="1">
+            <t:value lang="ru">Стадион Калининград</t:value>
+            <t:value lang="en">Kaliningrad Stadium</t:value>
+            <t:value lang="zh">加里宁格勒体育场</t:value>
+            <t:value lang="es">Estadio de Kaliningrado</t:value>
+          </t:option>
+          <t:option key="2">
+            <t:value lang="ru">Екатеринбург Арена</t:value>
+            <t:value lang="en">Volgograd Arena</t:value>
+            <t:value lang="zh">伏尔加格勒体育场</t:value>
+            <t:value lang="es">Volgogrado Arena</t:value>
+          </t:option>
+          <t:option key="3">
+            <t:value lang="ru">Казань Арена</t:value>
+            <t:value lang="en">Ekaterinburg Arena</t:value>
+            <t:value lang="zh">加里宁格勒体育场</t:value>
+            <t:value lang="es">Ekaterimburgo Arena</t:value>
+          </t:option>
+          <t:option key="4">
+            <t:value lang="ru">Мордовия Арена</t:value>
+            <t:value lang="en">Fisht Stadium</t:value>
+            <t:value lang="zh">费什体育场</t:value>
+            <t:value lang="es">Estadio Fisht</t:value>
+          </t:option>
+          <t:option key="5">
+            <t:value lang="ru">Ростов Арена</t:value>
+            <t:value lang="en">Kazan Arena</t:value>
+            <t:value lang="zh">喀山体育场</t:value>
+            <t:value lang="es">Kazan Arena</t:value>
+          </t:option>
+          <t:option key="6">
+            <t:value lang="ru">Самара Арена</t:value>
+            <t:value lang="en">Nizhny Novgorod Stadium</t:value>
+            <t:value lang="zh">下诺夫哥罗德体育场</t:value>
+            <t:value lang="es">Estadio de Nizhni Novgorod</t:value>
+          </t:option>
+          <t:option key="7">
+            <t:value lang="ru">Стадион Калининград</t:value>
+            <t:value lang="en">Luzhniki Stadium</t:value>
+            <t:value lang="zh">卢日尼基体育场</t:value>
+            <t:value lang="es">Estadio Luzhniki</t:value>
+          </t:option>
+          <t:option key="8">
+            <t:value lang="ru">Стадион Лужники</t:value>
+            <t:value lang="en">Samara Arena</t:value>
+            <t:value lang="zh">萨马拉体育场</t:value>
+            <t:value lang="es">Samara Arena</t:value>
+          </t:option>
+          <t:option key="9">
+            <t:value lang="ru">Стадион Нижний Новгород</t:value>
+            <t:value lang="en">Rostov Arena</t:value>
+            <t:value lang="zh">罗斯托夫体育场</t:value>
+            <t:value lang="es">Rostov Arena</t:value>
+          </t:option>
+          <t:option key="10">
+            <t:value lang="ru">Стадион Спартак</t:value>
+            <t:value lang="en">Spartak Stadium</t:value>
+            <t:value lang="zh">斯巴达克体育场</t:value>
+            <t:value lang="es">Estadio del Spartak</t:value>
+          </t:option>
+          <t:option key="11">
+            <t:value lang="ru">Стадион Санкт-Петербург</t:value>
+            <t:value lang="en">Saint Petersburg Stadium</t:value>
+            <t:value lang="zh">圣彼得堡体育场</t:value>
+            <t:value lang="es">Estadio de San Petersburgo</t:value>
+          </t:option>
+          <t:option key="12">
+            <t:value lang="ru">Стадион Фишт</t:value>
+            <t:value lang="en">Mordovia Arena</t:value>
+            <t:value lang="zh">莫多维亚体育场</t:value>
+            <t:value lang="es">Mordovia Arena</t:value>
+          </t:option>
+          <t:option key="255">
+            <t:value lang="en">UNSW Michael Crouch Innovation Center</t:value>
+            <t:value lang="zh">新南威尔大学Michael Crouch创新中心</t:value>
+            <t:value lang="es">Centro de Innovación de Michael Crouch UNSW</t:value>
+          </t:option>
+          <t:option key="254">
+            <t:value lang="en">FOUR SEASONS HOTEL SHENZHEN</t:value>
+            <t:value lang="zh">深圳四季酒店</t:value>
+          </t:option>
+          <t:option key="253">
+            <t:value lang="en">Paypal Innovation Lab</t:value>
+          </t:option>
+          <t:option key="252">
+            <t:value lang="en">The Centrepoint</t:value>
+          </t:option>
+          <t:option key="251">
+            <t:value lang="en">TBC</t:value>
+            <t:value lang="zh">待定</t:value>
+          </t:option>
+          <t:option key="250">
+            <t:value>thebridge</t:value>
+          </t:option>
+          <t:option key="249">
+            <t:value>BASH</t:value>
+          </t:option>
+          <t:option key="248">
+            <t:value>Spacemob</t:value>
+          </t:option>
+          <t:option key="247">
+            <t:value lang="en">32 Carpenter Street</t:value>
+          </t:option>
+          <t:option key="246">
+            <t:value>Block 71</t:value>
+          </t:option>
+          <t:option key="245">
+            <t:value lang="en">Microsoft Singapore</t:value>
+            <t:value lang="zh">微软新加坡</t:value>
+          </t:option>
+          <t:option key="243">
+            <t:value lang="en">Google Singapore</t:value>
+          </t:option>
+          <t:option key="242">
+            <t:value lang="en">The Blockchain Hub</t:value>
+          </t:option>
+          <t:option key="241">
+            <t:value>BitTemple</t:value>
+          </t:option>
+          <t:option key="240">
+            <t:value lang="en">ADD BLOCKCHAIN STUDIO</t:value>
+          </t:option>
+          <t:option key="239">
+            <t:value lang="en">Rosewood Beijing</t:value>
+            <t:value lang="zh">北京瑰丽酒店</t:value>
+          </t:option>
+          <t:option key="238">
+            <t:value lang="en">Stratum</t:value>
+            <t:value lang="zh">臻宛</t:value>
+          </t:option>
+          <t:option key="237">
+            <t:value lang="en">Hong Kong Convention and Exhibition Centre</t:value>
+            <t:value lang="zh">香港会议展览中心</t:value>
+          </t:option>
+          <t:option key="236">
+            <t:value lang="en">P2联合创业办公社 中关村e世界</t:value>
+            <t:value lang="zh">P2联合创业办公社 中关村e世界</t:value>
+          </t:option>
+          <t:option key="235">
+            <t:value lang="en">Fortune coffee@The Bund</t:value>
+            <t:value lang="zh">泛合金融咖啡@上海外滩</t:value>
+          </t:option>
+        </t:mapping>
       </t:origin>
     </t:attribute-type>
     <t:attribute-type id="time" syntax="1.3.6.1.4.1.1466.115.121.1.24">
@@ -494,14 +498,16 @@
       <!-- keys used here are BinaryTime (RFC6019) for backward compatibility,
            don't copy this behaviour when creating new assets -->
       <t:origin bitmask="000000000000000000000000000000000000FFFFFFFF00000000000000000000" as="mapping">
-	<!-- Shanghai -->
-        <t:option key="1531576800">
-          <t:value>20180714170000+0300</t:value>
-        </t:option>
-	<!-- Hong Kong -->
-        <t:option key="1531328400">
-          <t:value>20180711090000+0800</t:value>
-        </t:option>
+        <t:mapping>
+          <!-- Shanghai -->
+          <t:option key="1531576800">
+            <t:value>20180714170000+0300</t:value>
+          </t:option>
+          <!-- Hong Kong -->
+          <t:option key="1531328400">
+            <t:value>20180711090000+0800</t:value>
+          </t:option>
+        </t:mapping>
       </t:origin>
     </t:attribute-type>
     <t:attribute-type id="countryA" syntax="1.3.6.1.4.1.1466.115.121.1.26">
@@ -531,138 +537,140 @@
       <t:name lang="zh">等级</t:name>
       <t:name lang="es">Cat</t:name>
       <t:origin bitmask="0000000000000000000000000000000000000000000000000000000000FF0000" as="mapping">
-        <t:option key="1">
-          <t:value lang="en">Category 1</t:value>
-          <t:value lang="zh">一类票</t:value>
-        </t:option>
-        <t:option key="2">
-          <t:value lang="en">Category 2</t:value>
-          <t:value lang="zh">二类票</t:value>
-        </t:option>
-        <t:option key="3">
-          <t:value lang="en">Category 3</t:value>
-          <t:value lang="zh">三类票</t:value>
-        </t:option>
-        <t:option key="4">
-          <t:value lang="en">Category 4</t:value>
-          <t:value lang="zh">四类票</t:value>
-        </t:option>
-        <t:option key="5">
-          <t:value lang="en">Match Club</t:value>
-          <t:value lang="zh">俱乐部坐席</t:value>
-        </t:option>
-        <t:option key="6">
-          <t:value lang="en">Match House Premier</t:value>
-          <t:value lang="zh">比赛之家坐席</t:value>
-        </t:option>
-        <t:option key="7">
-          <t:value lang="en">MATCH PAVILION</t:value>
-          <t:value lang="zh">款待大厅坐席</t:value>
-        </t:option>
-        <t:option key="8">
-          <t:value lang="en">MATCH BUSINESS SEAT</t:value>
-          <t:value lang="zh">商务坐席</t:value>
-        </t:option>
-        <t:option key="9">
-          <t:value lang="en">MATCH SHARED SUITE</t:value>
-          <t:value lang="zh">公共包厢</t:value>
-        </t:option>
-        <t:option key="10">
-          <t:value lang="en">TSARSKY LOUNGE</t:value>
-          <t:value lang="zh">特拉斯基豪华包厢</t:value>
-        </t:option>
-        <t:option key="11">
-          <t:value lang="en">MATCH PRIVATE SUITE</t:value>
-          <t:value lang="zh">私人包厢</t:value>
-        </t:option>
-        <t:option key="255">
-          <t:value lang="en">Singapore Blockchain Event</t:value>
-          <t:value lang="zh">新加坡区块链活动</t:value>
-        </t:option>
-        <t:option key="254">
-          <t:value lang="en">TECHNOLOGY RADAR SUMMIT 2018</t:value>
-          <t:value lang="zh">技术雷达峰会2018</t:value>
-        </t:option>
-        <t:option key="253">
-          <t:value lang="en">Sydney Blockchain Event</t:value>
-          <t:value lang="zh">悉尼区块链活动</t:value>
-        </t:option>
-        <t:option key="252">
-          <t:value lang="en">Beijing Blockchain Event</t:value>
-          <t:value lang="zh">北京区块链活动</t:value>
-        </t:option>
-        <t:option key="251">
-          <t:value lang="en">Shanghai Blockchain Event</t:value>
-          <t:value lang="zh">上海区块链活动</t:value>
-        </t:option>
-        <t:option key="250">
-          <t:value lang="en">Tokyo Blockchain Event</t:value>
-          <t:value lang="zh">东京区块链活动</t:value>
-        </t:option>
-        <t:option key="249">
-          <t:value lang="en">Blockchain Event</t:value>
-          <t:value lang="zh">区块链活动</t:value>
-        </t:option>
-        <t:option key="248">
-          <t:value lang="en">Other Events</t:value>
-          <t:value lang="zh">其他活动</t:value>
-        </t:option>
-        <t:option key="247">
-          <t:value lang="en">Seoul Blockchain Event</t:value>
-          <t:value lang="zh">首尔区块链活动</t:value>
-        </t:option>
-        <t:option key="246">
-          <t:value lang="en">Bangkok Blockchain Event</t:value>
-          <t:value lang="zh">曼谷区块链活动</t:value>
-        </t:option>
-        <t:option key="245">
-          <t:value lang="en">AlphaWallet Event</t:value>
-          <t:value lang="zh">AlphaWallet活动</t:value>
-        </t:option>
-        <t:option key="243">
-          <t:value lang="en">Stormbird Event</t:value>
-          <t:value lang="zh">Stormbird活动</t:value>
-        </t:option>
-        <t:option key="242">
-          <t:value lang="en">UNITY VENTURES Event</t:value>
-          <t:value lang="zh">九合创投活动</t:value>
-        </t:option>
-        <t:option key="241">
-          <t:value lang="en">Max's Event</t:value>
-          <t:value lang="zh">Max的活动</t:value>
-        </t:option>
-        <t:option key="240">
-          <t:value lang="en">Chongqing Blockchain Event</t:value>
-          <t:value lang="zh">重庆区块链活动</t:value>
-        </t:option>
-        <t:option key="239">
-          <t:value lang="en">Dubai Blockchain Event</t:value>
-          <t:value lang="zh">迪拜区块链活动</t:value>
-        </t:option>
-        <t:option key="238">
-          <t:value lang="en">Silicon Valley Blockchain Event</t:value>
-          <t:value lang="zh">硅谷区块链活动</t:value>
-        </t:option>
-        <t:option key="237">
-          <t:value lang="en">Melbourne Blockchain Event</t:value>
-          <t:value lang="zh">墨尔本区块链活动</t:value>
-        </t:option>
-        <t:option key="236">
-          <t:value lang="en">General Event</t:value>
-          <t:value lang="zh">通用活动</t:value>
-        </t:option>
-        <t:option key="235">
-          <t:value lang="en">AlphaWallet Meeting Slot</t:value>
-          <t:value lang="zh">AlphaWallet面议机会</t:value>
-        </t:option>
-        <t:option key="234">
-          <t:value lang="en">ERC875 Meetup</t:value>
-          <t:value lang="zh">ERC875线下聚会</t:value>
-        </t:option>
-        <t:option key="233">
-          <t:value lang="en">Nervos and AlphaWallet Meetup</t:value>
-          <t:value lang="zh">Nervos和AlphaWallet见面会</t:value>
-        </t:option>
+        <t:mapping>
+          <t:option key="1">
+            <t:value lang="en">Category 1</t:value>
+            <t:value lang="zh">一类票</t:value>
+          </t:option>
+          <t:option key="2">
+            <t:value lang="en">Category 2</t:value>
+            <t:value lang="zh">二类票</t:value>
+          </t:option>
+          <t:option key="3">
+            <t:value lang="en">Category 3</t:value>
+            <t:value lang="zh">三类票</t:value>
+          </t:option>
+          <t:option key="4">
+            <t:value lang="en">Category 4</t:value>
+            <t:value lang="zh">四类票</t:value>
+          </t:option>
+          <t:option key="5">
+            <t:value lang="en">Match Club</t:value>
+            <t:value lang="zh">俱乐部坐席</t:value>
+          </t:option>
+          <t:option key="6">
+            <t:value lang="en">Match House Premier</t:value>
+            <t:value lang="zh">比赛之家坐席</t:value>
+          </t:option>
+          <t:option key="7">
+            <t:value lang="en">MATCH PAVILION</t:value>
+            <t:value lang="zh">款待大厅坐席</t:value>
+          </t:option>
+          <t:option key="8">
+            <t:value lang="en">MATCH BUSINESS SEAT</t:value>
+            <t:value lang="zh">商务坐席</t:value>
+          </t:option>
+          <t:option key="9">
+            <t:value lang="en">MATCH SHARED SUITE</t:value>
+            <t:value lang="zh">公共包厢</t:value>
+          </t:option>
+          <t:option key="10">
+            <t:value lang="en">TSARSKY LOUNGE</t:value>
+            <t:value lang="zh">特拉斯基豪华包厢</t:value>
+          </t:option>
+          <t:option key="11">
+            <t:value lang="en">MATCH PRIVATE SUITE</t:value>
+            <t:value lang="zh">私人包厢</t:value>
+          </t:option>
+          <t:option key="255">
+            <t:value lang="en">Singapore Blockchain Event</t:value>
+            <t:value lang="zh">新加坡区块链活动</t:value>
+          </t:option>
+          <t:option key="254">
+            <t:value lang="en">TECHNOLOGY RADAR SUMMIT 2018</t:value>
+            <t:value lang="zh">技术雷达峰会2018</t:value>
+          </t:option>
+          <t:option key="253">
+            <t:value lang="en">Sydney Blockchain Event</t:value>
+            <t:value lang="zh">悉尼区块链活动</t:value>
+          </t:option>
+          <t:option key="252">
+            <t:value lang="en">Beijing Blockchain Event</t:value>
+            <t:value lang="zh">北京区块链活动</t:value>
+          </t:option>
+          <t:option key="251">
+            <t:value lang="en">Shanghai Blockchain Event</t:value>
+            <t:value lang="zh">上海区块链活动</t:value>
+          </t:option>
+          <t:option key="250">
+            <t:value lang="en">Tokyo Blockchain Event</t:value>
+            <t:value lang="zh">东京区块链活动</t:value>
+          </t:option>
+          <t:option key="249">
+            <t:value lang="en">Blockchain Event</t:value>
+            <t:value lang="zh">区块链活动</t:value>
+          </t:option>
+          <t:option key="248">
+            <t:value lang="en">Other Events</t:value>
+            <t:value lang="zh">其他活动</t:value>
+          </t:option>
+          <t:option key="247">
+            <t:value lang="en">Seoul Blockchain Event</t:value>
+            <t:value lang="zh">首尔区块链活动</t:value>
+          </t:option>
+          <t:option key="246">
+            <t:value lang="en">Bangkok Blockchain Event</t:value>
+            <t:value lang="zh">曼谷区块链活动</t:value>
+          </t:option>
+          <t:option key="245">
+            <t:value lang="en">AlphaWallet Event</t:value>
+            <t:value lang="zh">AlphaWallet活动</t:value>
+          </t:option>
+          <t:option key="243">
+            <t:value lang="en">Stormbird Event</t:value>
+            <t:value lang="zh">Stormbird活动</t:value>
+          </t:option>
+          <t:option key="242">
+            <t:value lang="en">UNITY VENTURES Event</t:value>
+            <t:value lang="zh">九合创投活动</t:value>
+          </t:option>
+          <t:option key="241">
+            <t:value lang="en">Max's Event</t:value>
+            <t:value lang="zh">Max的活动</t:value>
+          </t:option>
+          <t:option key="240">
+            <t:value lang="en">Chongqing Blockchain Event</t:value>
+            <t:value lang="zh">重庆区块链活动</t:value>
+          </t:option>
+          <t:option key="239">
+            <t:value lang="en">Dubai Blockchain Event</t:value>
+            <t:value lang="zh">迪拜区块链活动</t:value>
+          </t:option>
+          <t:option key="238">
+            <t:value lang="en">Silicon Valley Blockchain Event</t:value>
+            <t:value lang="zh">硅谷区块链活动</t:value>
+          </t:option>
+          <t:option key="237">
+            <t:value lang="en">Melbourne Blockchain Event</t:value>
+            <t:value lang="zh">墨尔本区块链活动</t:value>
+          </t:option>
+          <t:option key="236">
+            <t:value lang="en">General Event</t:value>
+            <t:value lang="zh">通用活动</t:value>
+          </t:option>
+          <t:option key="235">
+            <t:value lang="en">AlphaWallet Meeting Slot</t:value>
+            <t:value lang="zh">AlphaWallet面议机会</t:value>
+          </t:option>
+          <t:option key="234">
+            <t:value lang="en">ERC875 Meetup</t:value>
+            <t:value lang="zh">ERC875线下聚会</t:value>
+          </t:option>
+          <t:option key="233">
+            <t:value lang="en">Nervos and AlphaWallet Meetup</t:value>
+            <t:value lang="zh">Nervos和AlphaWallet见面会</t:value>
+          </t:option>
+        </t:mapping>
       </t:origin>
     </t:attribute-type>
     <t:attribute-type id="numero" syntax="1.3.6.1.4.1.1466.115.121.1.27">

--- a/blockchain-tickets/schema1/blockchain-events-china.xml
+++ b/blockchain-tickets/schema1/blockchain-events-china.xml
@@ -173,176 +173,178 @@
       <tbml:name lang="es">Ciudad</tbml:name>
       <tbml:name lang="ru">город</tbml:name>
       <tbml:origin bitmask="00000000000000000000000000000000FF000000000000000000000000000000" as="mapping">
-        <tbml:option key="1">
-          <tbml:value lang="ru">Москва́</tbml:value>
-          <tbml:value lang="en">Moscow</tbml:value>
-          <tbml:value lang="zh">莫斯科</tbml:value>
-          <tbml:value lang="es">Moscú</tbml:value>
-        </tbml:option>
-        <tbml:option key="2">
-          <tbml:value lang="ru">Санкт-Петербу́рг</tbml:value>
-          <tbml:value lang="en">Saint Petersburg</tbml:value>
-          <tbml:value lang="zh">圣彼得堡</tbml:value>
-          <tbml:value lang="es">San Petersburgo</tbml:value>
-        </tbml:option>
-        <tbml:option key="3">
-          <tbml:value lang="ru">сочи</tbml:value>
-          <tbml:value lang="en">Sochi</tbml:value>
-          <tbml:value lang="zh">索契</tbml:value>
-          <tbml:value lang="es">Sochi</tbml:value>
-        </tbml:option>
-        <tbml:option key="4">
-          <tbml:value lang="ru">екатеринбург</tbml:value>
-          <tbml:value lang="en">Ekaterinburg</tbml:value>
-          <tbml:value lang="zh">叶卡捷琳堡</tbml:value>
-          <tbml:value lang="es">Ekaterinburg</tbml:value>
-        </tbml:option>
-        <tbml:option key="5">
-          <tbml:value lang="ru">Саранск</tbml:value>
-          <tbml:value lang="en">Saransk</tbml:value>
-          <tbml:value lang="zh">萨兰斯克</tbml:value>
-          <tbml:value lang="es">Saransk</tbml:value>
-        </tbml:option>
-        <tbml:option key="6">
-          <tbml:value lang="ru">казань</tbml:value>
-          <tbml:value lang="en">Kazan</tbml:value>
-          <tbml:value lang="zh">喀山</tbml:value>
-          <tbml:value lang="es">Kazan</tbml:value>
-        </tbml:option>
-        <tbml:option key="7">
-          <tbml:value lang="ru">Нижний Новгород</tbml:value>
-          <tbml:value lang="en">Nizhny Novgorod</tbml:value>
-          <tbml:value lang="zh">下诺夫哥罗德</tbml:value>
-          <tbml:value lang="es">Nizhny Novgorod</tbml:value>
-        </tbml:option>
-        <tbml:option key="8">
-          <tbml:value lang="ru">Ростов-на-Дону</tbml:value>
-          <tbml:value lang="en">Rostov-on-Don</tbml:value>
-          <tbml:value lang="zh">顿河畔罗斯托夫</tbml:value>
-          <tbml:value lang="es">Rostov-on-Don</tbml:value>
-        </tbml:option>
-        <tbml:option key="9">
-          <tbml:value lang="ru">Самара</tbml:value>
-          <tbml:value lang="en">Samara</tbml:value>
-          <tbml:value lang="zh">萨马拉</tbml:value>
-          <tbml:value lang="es">Samara</tbml:value>
-        </tbml:option>
-        <tbml:option key="10">
-          <tbml:value lang="ru">Волгоград</tbml:value>
-          <tbml:value lang="en">Volgograd</tbml:value>
-          <tbml:value lang="zh">伏尔加格勒</tbml:value>
-          <tbml:value lang="es">Volgogrado</tbml:value>
-        </tbml:option>
-        <tbml:option key="11">
-          <tbml:value lang="ru">Калининград</tbml:value>
-          <tbml:value lang="en">Kaliningrad</tbml:value>
-          <tbml:value lang="zh">加里宁格勒</tbml:value>
-          <tbml:value lang="es">Kaliningrad</tbml:value>
-        </tbml:option>
-        <tbml:option key="255">
-          <tbml:value lang="ru">Сидней</tbml:value>
-          <tbml:value lang="en">Sydney</tbml:value>
-          <tbml:value lang="zh">悉尼</tbml:value>
-          <tbml:value lang="es">Sídney</tbml:value>
-        </tbml:option>
-        <tbml:option key="254">
-          <tbml:value lang="ru">Сингапур</tbml:value>
-          <tbml:value lang="en">Singapore</tbml:value>
-          <tbml:value lang="zh">新加坡</tbml:value>
-          <tbml:value lang="es">Singapur</tbml:value>
-        </tbml:option>
-        <tbml:option key="253">
-          <tbml:value lang="zh">深圳</tbml:value>
-          <tbml:value lang="en">Shenzhen</tbml:value>
-        </tbml:option>
-        <tbml:option key="252">
-          <tbml:value lang="zh">北京</tbml:value>
-          <tbml:value lang="en">Beijing</tbml:value>
-        </tbml:option>
-        <tbml:option key="251">
-          <tbml:value lang="zh">上海</tbml:value>
-          <tbml:value lang="en">Shanghai</tbml:value>
-        </tbml:option>
-        <tbml:option key="250">
-          <tbml:value lang="en">Tokyo</tbml:value>
-          <tbml:value lang="zh">东京</tbml:value>
-        </tbml:option>
-        <tbml:option key="249">
-          <tbml:value lang="en">Seoul</tbml:value>
-          <tbml:value lang="zh">首尔</tbml:value>
-        </tbml:option>
-        <tbml:option key="248">
-          <tbml:value lang="zh">重庆</tbml:value>
-          <tbml:value lang="en">Chongqing</tbml:value>
-        </tbml:option>
-        <tbml:option key="247">
-          <tbml:value lang="en">New York</tbml:value>
-          <tbml:value lang="zh">纽约</tbml:value>
-        </tbml:option>
-        <tbml:option key="246">
-          <tbml:value lang="en">Melbourne</tbml:value>
-          <tbml:value lang="zh">墨尔本</tbml:value>
-        </tbml:option>
-        <tbml:option key="245">
-          <tbml:value lang="en">Hong Kong</tbml:value>
-          <tbml:value lang="zh">香港</tbml:value>
-        </tbml:option>
-        <tbml:option key="244">
-          <tbml:value lang="zh">成都</tbml:value>
-          <tbml:value lang="en">Chengdu</tbml:value>
-        </tbml:option>
-        <tbml:option key="243">
-          <tbml:value lang="en">Kuala Lumpur</tbml:value>
-          <tbml:value lang="zh">吉隆坡</tbml:value>
-        </tbml:option>
-        <tbml:option key="242">
-          <tbml:value lang="en">Bangkok</tbml:value>
-          <tbml:value lang="zh">曼谷</tbml:value>
-        </tbml:option>
-        <tbml:option key="241">
-          <tbml:value lang="en">San Francisco</tbml:value>
-          <tbml:value lang="zh">三藩市</tbml:value>
-        </tbml:option>
-        <tbml:option key="240">
-          <tbml:value lang="en">Las Vegas</tbml:value>
-          <tbml:value lang="zh">拉斯维加斯</tbml:value>
-        </tbml:option>
-        <tbml:option key="239">
-          <tbml:value lang="en">London</tbml:value>
-          <tbml:value lang="zh">伦敦</tbml:value>
-        </tbml:option>
-        <tbml:option key="238">
-          <tbml:value lang="en">Barcelona</tbml:value>
-          <tbml:value lang="zh">巴塞罗那</tbml:value>
-        </tbml:option>
-        <tbml:option key="237">
-          <tbml:value lang="en">Madrid</tbml:value>
-          <tbml:value lang="zh">马德里</tbml:value>
-        </tbml:option>
-        <tbml:option key="236">
-          <tbml:value lang="en">Zug</tbml:value>
-          <tbml:value lang="zh">楚格</tbml:value>
-        </tbml:option>
-        <tbml:option key="235">
-          <tbml:value lang="en">Paris</tbml:value>
-          <tbml:value lang="zh">巴黎</tbml:value>
-        </tbml:option>
-        <tbml:option key="234">
-          <tbml:value lang="en">Dubai</tbml:value>
-          <tbml:value lang="zh">迪拜</tbml:value>
-        </tbml:option>
-        <tbml:option key="233">
-          <tbml:value lang="en">TBC</tbml:value>
-          <tbml:value lang="zh">待定</tbml:value>
-        </tbml:option>
-         <tbml:option key="232">
-          <tbml:value lang="en">Exhibition stand A311</tbml:value>
-          <tbml:value lang="zh">展台A311</tbml:value>
-        </tbml:option>
-        <tbml:option key="231">
-          <tbml:value lang="en">Prague</tbml:value>
-          <tbml:value lang="zh">布拉格</tbml:value>
-        </tbml:option>
+        <tbml:mapping>
+          <tbml:option key="1">
+            <tbml:value lang="ru">Москва́</tbml:value>
+            <tbml:value lang="en">Moscow</tbml:value>
+            <tbml:value lang="zh">莫斯科</tbml:value>
+            <tbml:value lang="es">Moscú</tbml:value>
+          </tbml:option>
+          <tbml:option key="2">
+            <tbml:value lang="ru">Санкт-Петербу́рг</tbml:value>
+            <tbml:value lang="en">Saint Petersburg</tbml:value>
+            <tbml:value lang="zh">圣彼得堡</tbml:value>
+            <tbml:value lang="es">San Petersburgo</tbml:value>
+          </tbml:option>
+          <tbml:option key="3">
+            <tbml:value lang="ru">сочи</tbml:value>
+            <tbml:value lang="en">Sochi</tbml:value>
+            <tbml:value lang="zh">索契</tbml:value>
+            <tbml:value lang="es">Sochi</tbml:value>
+          </tbml:option>
+          <tbml:option key="4">
+            <tbml:value lang="ru">екатеринбург</tbml:value>
+            <tbml:value lang="en">Ekaterinburg</tbml:value>
+            <tbml:value lang="zh">叶卡捷琳堡</tbml:value>
+            <tbml:value lang="es">Ekaterinburg</tbml:value>
+          </tbml:option>
+          <tbml:option key="5">
+            <tbml:value lang="ru">Саранск</tbml:value>
+            <tbml:value lang="en">Saransk</tbml:value>
+            <tbml:value lang="zh">萨兰斯克</tbml:value>
+            <tbml:value lang="es">Saransk</tbml:value>
+          </tbml:option>
+          <tbml:option key="6">
+            <tbml:value lang="ru">казань</tbml:value>
+            <tbml:value lang="en">Kazan</tbml:value>
+            <tbml:value lang="zh">喀山</tbml:value>
+            <tbml:value lang="es">Kazan</tbml:value>
+          </tbml:option>
+          <tbml:option key="7">
+            <tbml:value lang="ru">Нижний Новгород</tbml:value>
+            <tbml:value lang="en">Nizhny Novgorod</tbml:value>
+            <tbml:value lang="zh">下诺夫哥罗德</tbml:value>
+            <tbml:value lang="es">Nizhny Novgorod</tbml:value>
+          </tbml:option>
+          <tbml:option key="8">
+            <tbml:value lang="ru">Ростов-на-Дону</tbml:value>
+            <tbml:value lang="en">Rostov-on-Don</tbml:value>
+            <tbml:value lang="zh">顿河畔罗斯托夫</tbml:value>
+            <tbml:value lang="es">Rostov-on-Don</tbml:value>
+          </tbml:option>
+          <tbml:option key="9">
+            <tbml:value lang="ru">Самара</tbml:value>
+            <tbml:value lang="en">Samara</tbml:value>
+            <tbml:value lang="zh">萨马拉</tbml:value>
+            <tbml:value lang="es">Samara</tbml:value>
+          </tbml:option>
+          <tbml:option key="10">
+            <tbml:value lang="ru">Волгоград</tbml:value>
+            <tbml:value lang="en">Volgograd</tbml:value>
+            <tbml:value lang="zh">伏尔加格勒</tbml:value>
+            <tbml:value lang="es">Volgogrado</tbml:value>
+          </tbml:option>
+          <tbml:option key="11">
+            <tbml:value lang="ru">Калининград</tbml:value>
+            <tbml:value lang="en">Kaliningrad</tbml:value>
+            <tbml:value lang="zh">加里宁格勒</tbml:value>
+            <tbml:value lang="es">Kaliningrad</tbml:value>
+          </tbml:option>
+          <tbml:option key="255">
+            <tbml:value lang="ru">Сидней</tbml:value>
+            <tbml:value lang="en">Sydney</tbml:value>
+            <tbml:value lang="zh">悉尼</tbml:value>
+            <tbml:value lang="es">Sídney</tbml:value>
+          </tbml:option>
+          <tbml:option key="254">
+            <tbml:value lang="ru">Сингапур</tbml:value>
+            <tbml:value lang="en">Singapore</tbml:value>
+            <tbml:value lang="zh">新加坡</tbml:value>
+            <tbml:value lang="es">Singapur</tbml:value>
+          </tbml:option>
+          <tbml:option key="253">
+            <tbml:value lang="zh">深圳</tbml:value>
+            <tbml:value lang="en">Shenzhen</tbml:value>
+          </tbml:option>
+          <tbml:option key="252">
+            <tbml:value lang="zh">北京</tbml:value>
+            <tbml:value lang="en">Beijing</tbml:value>
+          </tbml:option>
+          <tbml:option key="251">
+            <tbml:value lang="zh">上海</tbml:value>
+            <tbml:value lang="en">Shanghai</tbml:value>
+          </tbml:option>
+          <tbml:option key="250">
+            <tbml:value lang="en">Tokyo</tbml:value>
+            <tbml:value lang="zh">东京</tbml:value>
+          </tbml:option>
+          <tbml:option key="249">
+            <tbml:value lang="en">Seoul</tbml:value>
+            <tbml:value lang="zh">首尔</tbml:value>
+          </tbml:option>
+          <tbml:option key="248">
+            <tbml:value lang="zh">重庆</tbml:value>
+            <tbml:value lang="en">Chongqing</tbml:value>
+          </tbml:option>
+          <tbml:option key="247">
+            <tbml:value lang="en">New York</tbml:value>
+            <tbml:value lang="zh">纽约</tbml:value>
+          </tbml:option>
+          <tbml:option key="246">
+            <tbml:value lang="en">Melbourne</tbml:value>
+            <tbml:value lang="zh">墨尔本</tbml:value>
+          </tbml:option>
+          <tbml:option key="245">
+            <tbml:value lang="en">Hong Kong</tbml:value>
+            <tbml:value lang="zh">香港</tbml:value>
+          </tbml:option>
+          <tbml:option key="244">
+            <tbml:value lang="zh">成都</tbml:value>
+            <tbml:value lang="en">Chengdu</tbml:value>
+          </tbml:option>
+          <tbml:option key="243">
+            <tbml:value lang="en">Kuala Lumpur</tbml:value>
+            <tbml:value lang="zh">吉隆坡</tbml:value>
+          </tbml:option>
+          <tbml:option key="242">
+            <tbml:value lang="en">Bangkok</tbml:value>
+            <tbml:value lang="zh">曼谷</tbml:value>
+          </tbml:option>
+          <tbml:option key="241">
+            <tbml:value lang="en">San Francisco</tbml:value>
+            <tbml:value lang="zh">三藩市</tbml:value>
+          </tbml:option>
+          <tbml:option key="240">
+            <tbml:value lang="en">Las Vegas</tbml:value>
+            <tbml:value lang="zh">拉斯维加斯</tbml:value>
+          </tbml:option>
+          <tbml:option key="239">
+            <tbml:value lang="en">London</tbml:value>
+            <tbml:value lang="zh">伦敦</tbml:value>
+          </tbml:option>
+          <tbml:option key="238">
+            <tbml:value lang="en">Barcelona</tbml:value>
+            <tbml:value lang="zh">巴塞罗那</tbml:value>
+          </tbml:option>
+          <tbml:option key="237">
+            <tbml:value lang="en">Madrid</tbml:value>
+            <tbml:value lang="zh">马德里</tbml:value>
+          </tbml:option>
+          <tbml:option key="236">
+            <tbml:value lang="en">Zug</tbml:value>
+            <tbml:value lang="zh">楚格</tbml:value>
+          </tbml:option>
+          <tbml:option key="235">
+            <tbml:value lang="en">Paris</tbml:value>
+            <tbml:value lang="zh">巴黎</tbml:value>
+          </tbml:option>
+          <tbml:option key="234">
+            <tbml:value lang="en">Dubai</tbml:value>
+            <tbml:value lang="zh">迪拜</tbml:value>
+          </tbml:option>
+          <tbml:option key="233">
+            <tbml:value lang="en">TBC</tbml:value>
+            <tbml:value lang="zh">待定</tbml:value>
+          </tbml:option>
+          <tbml:option key="232">
+            <tbml:value lang="en">Exhibition stand A311</tbml:value>
+            <tbml:value lang="zh">展台A311</tbml:value>
+          </tbml:option>
+          <tbml:option key="231">
+            <tbml:value lang="en">Prague</tbml:value>
+            <tbml:value lang="zh">布拉格</tbml:value>
+          </tbml:option>
+        </tbml:mapping>
       </tbml:origin>
     </tbml:attribute-type>
     <tbml:attribute-type id="venue" syntax="1.3.6.1.4.1.1466.115.121.1.15">
@@ -351,152 +353,154 @@
       <tbml:name lang="es">Lugar</tbml:name>
       <tbml:name lang="ru">место встречи</tbml:name>
       <tbml:origin bitmask="0000000000000000000000000000000000FF0000000000000000000000000000" as="mapping">
-        <tbml:option key="1">
-          <tbml:value lang="ru">Стадион Калининград</tbml:value>
-          <tbml:value lang="en">Kaliningrad Stadium</tbml:value>
-          <tbml:value lang="zh">加里宁格勒体育场</tbml:value>
-          <tbml:value lang="es">Estadio de Kaliningrado</tbml:value>
-        </tbml:option>
-        <tbml:option key="2">
-          <tbml:value lang="ru">Екатеринбург Арена</tbml:value>
-          <tbml:value lang="en">Volgograd Arena</tbml:value>
-          <tbml:value lang="zh">伏尔加格勒体育场</tbml:value>
-          <tbml:value lang="es">Volgogrado Arena</tbml:value>
-        </tbml:option>
-        <tbml:option key="3">
-          <tbml:value lang="ru">Казань Арена</tbml:value>
-          <tbml:value lang="en">Ekaterinburg Arena</tbml:value>
-          <tbml:value lang="zh">加里宁格勒体育场</tbml:value>
-          <tbml:value lang="es">Ekaterimburgo Arena</tbml:value>
-        </tbml:option>
-        <tbml:option key="4">
-          <tbml:value lang="ru">Мордовия Арена</tbml:value>
-          <tbml:value lang="en">Fisht Stadium</tbml:value>
-          <tbml:value lang="zh">费什体育场</tbml:value>
-          <tbml:value lang="es">Estadio Fisht</tbml:value>
-        </tbml:option>
-        <tbml:option key="5">
-          <tbml:value lang="ru">Ростов Арена</tbml:value>
-          <tbml:value lang="en">Kazan Arena</tbml:value>
-          <tbml:value lang="zh">喀山体育场</tbml:value>
-          <tbml:value lang="es">Kazan Arena</tbml:value>
-        </tbml:option>
-        <tbml:option key="6">
-          <tbml:value lang="ru">Самара Арена</tbml:value>
-          <tbml:value lang="en">Nizhny Novgorod Stadium</tbml:value>
-          <tbml:value lang="zh">下诺夫哥罗德体育场</tbml:value>
-          <tbml:value lang="es">Estadio de Nizhni Novgorod</tbml:value>
-        </tbml:option>
-        <tbml:option key="7">
-          <tbml:value lang="ru">Стадион Калининград</tbml:value>
-          <tbml:value lang="en">Luzhniki Stadium</tbml:value>
-          <tbml:value lang="zh">卢日尼基体育场</tbml:value>
-          <tbml:value lang="es">Estadio Luzhniki</tbml:value>
-        </tbml:option>
-        <tbml:option key="8">
-          <tbml:value lang="ru">Стадион Лужники</tbml:value>
-          <tbml:value lang="en">Samara Arena</tbml:value>
-          <tbml:value lang="zh">萨马拉体育场</tbml:value>
-          <tbml:value lang="es">Samara Arena</tbml:value>
-        </tbml:option>
-        <tbml:option key="9">
-          <tbml:value lang="ru">Стадион Нижний Новгород</tbml:value>
-          <tbml:value lang="en">Rostov Arena</tbml:value>
-          <tbml:value lang="zh">罗斯托夫体育场</tbml:value>
-          <tbml:value lang="es">Rostov Arena</tbml:value>
-        </tbml:option>
-        <tbml:option key="10">
-          <tbml:value lang="ru">Стадион Спартак</tbml:value>
-          <tbml:value lang="en">Spartak Stadium</tbml:value>
-          <tbml:value lang="zh">斯巴达克体育场</tbml:value>
-          <tbml:value lang="es">Estadio del Spartak</tbml:value>
-        </tbml:option>
-        <tbml:option key="11">
-          <tbml:value lang="ru">Стадион Санкт-Петербург</tbml:value>
-          <tbml:value lang="en">Saint Petersburg Stadium</tbml:value>
-          <tbml:value lang="zh">圣彼得堡体育场</tbml:value>
-          <tbml:value lang="es">Estadio de San Petersburgo</tbml:value>
-        </tbml:option>
-        <tbml:option key="12">
-          <tbml:value lang="ru">Стадион Фишт</tbml:value>
-          <tbml:value lang="en">Mordovia Arena</tbml:value>
-          <tbml:value lang="zh">莫多维亚体育场</tbml:value>
-          <tbml:value lang="es">Mordovia Arena</tbml:value>
-        </tbml:option>
-        <tbml:option key="255">
-          <tbml:value lang="en">UNSW Michael Crouch Innovation Center</tbml:value>
-          <tbml:value lang="zh">新南威尔大学Michael Crouch创新中心</tbml:value>
-          <tbml:value lang="es">Centro de Innovación de Michael Crouch UNSW</tbml:value>
-        </tbml:option>
-        <tbml:option key="254">
-          <tbml:value lang="en">FOUR SEASONS HOTEL SHENZHEN</tbml:value>
-          <tbml:value lang="zh">深圳四季酒店</tbml:value>
-        </tbml:option>
-        <tbml:option key="253">
-          <tbml:value lang="en">Paypal Innovation Lab</tbml:value>
-        </tbml:option>
-        <tbml:option key="252">
-          <tbml:value lang="en">The Centrepoint</tbml:value>
-        </tbml:option>
-        <tbml:option key="251">
-          <tbml:value lang="en">TBC</tbml:value>
-          <tbml:value lang="zh">待定</tbml:value>
-        </tbml:option>
-        <tbml:option key="250">
-          <tbml:value>thebridge</tbml:value>
-        </tbml:option>
-        <tbml:option key="249">
-          <tbml:value>BASH</tbml:value>
-        </tbml:option>
-        <tbml:option key="248">
-          <tbml:value>Spacemob</tbml:value>
-        </tbml:option>
-        <tbml:option key="247">
-          <tbml:value lang="en">32 Carpenter Street</tbml:value>
-        </tbml:option>
-        <tbml:option key="246">
-          <tbml:value>Block 71</tbml:value>
-        </tbml:option>
-        <tbml:option key="245">
-          <tbml:value lang="en">Microsoft Singapore</tbml:value>
-          <tbml:value lang="zh">微软新加坡</tbml:value>
-        </tbml:option>
-        <tbml:option key="243">
-          <tbml:value lang="en">Google Singapore</tbml:value>
-        </tbml:option>
-        <tbml:option key="242">
-          <tbml:value lang="en">The Blockchain Hub</tbml:value>
-        </tbml:option>
-        <tbml:option key="241">
-          <tbml:value>BitTemple</tbml:value>
-        </tbml:option>
-        <tbml:option key="240">
-          <tbml:value lang="en">ADD BLOCKCHAIN STUDIO</tbml:value>
-        </tbml:option>
-        <tbml:option key="239">
-          <tbml:value lang="en">Rosewood Beijing</tbml:value>
-          <tbml:value lang="zh">北京瑰丽酒店</tbml:value>
-        </tbml:option>
-        <tbml:option key="238">
-          <tbml:value lang="en">Stratum</tbml:value>
-          <tbml:value lang="zh">臻宛</tbml:value>
-        </tbml:option>
-        <tbml:option key="237">
-          <tbml:value lang="en">Hong Kong Convention and Exhibition Centre</tbml:value>
-          <tbml:value lang="zh">香港会议展览中心</tbml:value>
-        </tbml:option>
-        <tbml:option key="236">
-          <tbml:value lang="en">P2联合创业办公社 中关村e世界</tbml:value>
-          <tbml:value lang="zh">P2联合创业办公社 中关村e世界</tbml:value>
-        </tbml:option>
-        <tbml:option key="235">
-          <tbml:value lang="en">Fortune coffee@The Bund</tbml:value>
-          <tbml:value lang="zh">泛合金融咖啡@上海外滩</tbml:value>
-        </tbml:option>
-        <tbml:option key="234">
-          <tbml:value lang="en">Paralelní Polis</tbml:value>
-          <tbml:value lang="zh">Paralelní Polis</tbml:value>
-        </tbml:option>        
+        <tbml:mapping>
+          <tbml:option key="1">
+            <tbml:value lang="ru">Стадион Калининград</tbml:value>
+            <tbml:value lang="en">Kaliningrad Stadium</tbml:value>
+            <tbml:value lang="zh">加里宁格勒体育场</tbml:value>
+            <tbml:value lang="es">Estadio de Kaliningrado</tbml:value>
+          </tbml:option>
+          <tbml:option key="2">
+            <tbml:value lang="ru">Екатеринбург Арена</tbml:value>
+            <tbml:value lang="en">Volgograd Arena</tbml:value>
+            <tbml:value lang="zh">伏尔加格勒体育场</tbml:value>
+            <tbml:value lang="es">Volgogrado Arena</tbml:value>
+          </tbml:option>
+          <tbml:option key="3">
+            <tbml:value lang="ru">Казань Арена</tbml:value>
+            <tbml:value lang="en">Ekaterinburg Arena</tbml:value>
+            <tbml:value lang="zh">加里宁格勒体育场</tbml:value>
+            <tbml:value lang="es">Ekaterimburgo Arena</tbml:value>
+          </tbml:option>
+          <tbml:option key="4">
+            <tbml:value lang="ru">Мордовия Арена</tbml:value>
+            <tbml:value lang="en">Fisht Stadium</tbml:value>
+            <tbml:value lang="zh">费什体育场</tbml:value>
+            <tbml:value lang="es">Estadio Fisht</tbml:value>
+          </tbml:option>
+          <tbml:option key="5">
+            <tbml:value lang="ru">Ростов Арена</tbml:value>
+            <tbml:value lang="en">Kazan Arena</tbml:value>
+            <tbml:value lang="zh">喀山体育场</tbml:value>
+            <tbml:value lang="es">Kazan Arena</tbml:value>
+          </tbml:option>
+          <tbml:option key="6">
+            <tbml:value lang="ru">Самара Арена</tbml:value>
+            <tbml:value lang="en">Nizhny Novgorod Stadium</tbml:value>
+            <tbml:value lang="zh">下诺夫哥罗德体育场</tbml:value>
+            <tbml:value lang="es">Estadio de Nizhni Novgorod</tbml:value>
+          </tbml:option>
+          <tbml:option key="7">
+            <tbml:value lang="ru">Стадион Калининград</tbml:value>
+            <tbml:value lang="en">Luzhniki Stadium</tbml:value>
+            <tbml:value lang="zh">卢日尼基体育场</tbml:value>
+            <tbml:value lang="es">Estadio Luzhniki</tbml:value>
+          </tbml:option>
+          <tbml:option key="8">
+            <tbml:value lang="ru">Стадион Лужники</tbml:value>
+            <tbml:value lang="en">Samara Arena</tbml:value>
+            <tbml:value lang="zh">萨马拉体育场</tbml:value>
+            <tbml:value lang="es">Samara Arena</tbml:value>
+          </tbml:option>
+          <tbml:option key="9">
+            <tbml:value lang="ru">Стадион Нижний Новгород</tbml:value>
+            <tbml:value lang="en">Rostov Arena</tbml:value>
+            <tbml:value lang="zh">罗斯托夫体育场</tbml:value>
+            <tbml:value lang="es">Rostov Arena</tbml:value>
+          </tbml:option>
+          <tbml:option key="10">
+            <tbml:value lang="ru">Стадион Спартак</tbml:value>
+            <tbml:value lang="en">Spartak Stadium</tbml:value>
+            <tbml:value lang="zh">斯巴达克体育场</tbml:value>
+            <tbml:value lang="es">Estadio del Spartak</tbml:value>
+          </tbml:option>
+          <tbml:option key="11">
+            <tbml:value lang="ru">Стадион Санкт-Петербург</tbml:value>
+            <tbml:value lang="en">Saint Petersburg Stadium</tbml:value>
+            <tbml:value lang="zh">圣彼得堡体育场</tbml:value>
+            <tbml:value lang="es">Estadio de San Petersburgo</tbml:value>
+          </tbml:option>
+          <tbml:option key="12">
+            <tbml:value lang="ru">Стадион Фишт</tbml:value>
+            <tbml:value lang="en">Mordovia Arena</tbml:value>
+            <tbml:value lang="zh">莫多维亚体育场</tbml:value>
+            <tbml:value lang="es">Mordovia Arena</tbml:value>
+          </tbml:option>
+          <tbml:option key="255">
+            <tbml:value lang="en">UNSW Michael Crouch Innovation Center</tbml:value>
+            <tbml:value lang="zh">新南威尔大学Michael Crouch创新中心</tbml:value>
+            <tbml:value lang="es">Centro de Innovación de Michael Crouch UNSW</tbml:value>
+          </tbml:option>
+          <tbml:option key="254">
+            <tbml:value lang="en">FOUR SEASONS HOTEL SHENZHEN</tbml:value>
+            <tbml:value lang="zh">深圳四季酒店</tbml:value>
+          </tbml:option>
+          <tbml:option key="253">
+            <tbml:value lang="en">Paypal Innovation Lab</tbml:value>
+          </tbml:option>
+          <tbml:option key="252">
+            <tbml:value lang="en">The Centrepoint</tbml:value>
+          </tbml:option>
+          <tbml:option key="251">
+            <tbml:value lang="en">TBC</tbml:value>
+            <tbml:value lang="zh">待定</tbml:value>
+          </tbml:option>
+          <tbml:option key="250">
+            <tbml:value>thebridge</tbml:value>
+          </tbml:option>
+          <tbml:option key="249">
+            <tbml:value>BASH</tbml:value>
+          </tbml:option>
+          <tbml:option key="248">
+            <tbml:value>Spacemob</tbml:value>
+          </tbml:option>
+          <tbml:option key="247">
+            <tbml:value lang="en">32 Carpenter Street</tbml:value>
+          </tbml:option>
+          <tbml:option key="246">
+            <tbml:value>Block 71</tbml:value>
+          </tbml:option>
+          <tbml:option key="245">
+            <tbml:value lang="en">Microsoft Singapore</tbml:value>
+            <tbml:value lang="zh">微软新加坡</tbml:value>
+          </tbml:option>
+          <tbml:option key="243">
+            <tbml:value lang="en">Google Singapore</tbml:value>
+          </tbml:option>
+          <tbml:option key="242">
+            <tbml:value lang="en">The Blockchain Hub</tbml:value>
+          </tbml:option>
+          <tbml:option key="241">
+            <tbml:value>BitTemple</tbml:value>
+          </tbml:option>
+          <tbml:option key="240">
+            <tbml:value lang="en">ADD BLOCKCHAIN STUDIO</tbml:value>
+          </tbml:option>
+          <tbml:option key="239">
+            <tbml:value lang="en">Rosewood Beijing</tbml:value>
+            <tbml:value lang="zh">北京瑰丽酒店</tbml:value>
+          </tbml:option>
+          <tbml:option key="238">
+            <tbml:value lang="en">Stratum</tbml:value>
+            <tbml:value lang="zh">臻宛</tbml:value>
+          </tbml:option>
+          <tbml:option key="237">
+            <tbml:value lang="en">Hong Kong Convention and Exhibition Centre</tbml:value>
+            <tbml:value lang="zh">香港会议展览中心</tbml:value>
+          </tbml:option>
+          <tbml:option key="236">
+            <tbml:value lang="en">P2联合创业办公社 中关村e世界</tbml:value>
+            <tbml:value lang="zh">P2联合创业办公社 中关村e世界</tbml:value>
+          </tbml:option>
+          <tbml:option key="235">
+            <tbml:value lang="en">Fortune coffee@The Bund</tbml:value>
+            <tbml:value lang="zh">泛合金融咖啡@上海外滩</tbml:value>
+          </tbml:option>
+          <tbml:option key="234">
+            <tbml:value lang="en">Paralelní Polis</tbml:value>
+            <tbml:value lang="zh">Paralelní Polis</tbml:value>
+          </tbml:option>
+        </tbml:mapping>
       </tbml:origin>
     </tbml:attribute-type>
     <tbml:attribute-type id="time" syntax="1.3.6.1.4.1.1466.115.121.1.24">
@@ -507,36 +511,38 @@
       <!-- keys used here are BinaryTime (RFC6019) for backward compatibility,
            don't copy this behaviour when creating new assets -->
       <tbml:origin bitmask="000000000000000000000000000000000000FFFFFFFF00000000000000000000" as="mapping">
-        <!-- $ TZ=Europe/Moscow date -d @1528988400 +%Y%m%d%H%M%S%z -->
-        <tbml:option key="1528988400">
-          <tbml:value>20180614180000+0300</tbml:value>
-        </tbml:option>
-        <!-- $ TZ=Europe/Moscow date -d @1529074800 +%Y%m%d%H%M%S%z -->
-        <tbml:option key="1529074800">
-          <tbml:value>20180615180000+0300</tbml:value>
-        </tbml:option>
-        <!-- $ TZ=Europe/Moscow date -d @1529420400 +%Y%m%d%H%M%S%z -->
-        <tbml:option key="1529420400">
-          <tbml:value>20180619180000+0300</tbml:value>
-        </tbml:option>
-        <!-- $ TZ=Europe/Moscow date -d @1529431200 +%Y%m%d%H%M%S%z -->
-        <tbml:option key="1529431200">
-          <tbml:value>20180619210000+0300</tbml:value>
-        </tbml:option>
-        <!-- $ TZ=Europe/Moscow date -d @1530900000 +%Y%m%d%H%M%S%z -->
-        <tbml:option key="1530900000">
-          <tbml:value>20180706210000+0300</tbml:value>
-        </tbml:option>
-        <!-- $ TZ=Europe/Moscow date -d @1531576800 +%Y%m%d%H%M%S%z -->
-        <tbml:option key="1531576800">
-          <tbml:value>20180714170000+0300</tbml:value>
-        </tbml:option>
-        <tbml:option key="1536778800">
-          <tbml:value>20180911190000+0800</tbml:value>
-        </tbml:option>
-        <tbml:option key="1536692400">
-          <tbml:value>20180911190000+0800</tbml:value>
-        </tbml:option>
+        <tbml:mapping>
+          <!-- $ TZ=Europe/Moscow date -d @1528988400 +%Y%m%d%H%M%S%z -->
+          <tbml:option key="1528988400">
+            <tbml:value>20180614180000+0300</tbml:value>
+          </tbml:option>
+          <!-- $ TZ=Europe/Moscow date -d @1529074800 +%Y%m%d%H%M%S%z -->
+          <tbml:option key="1529074800">
+            <tbml:value>20180615180000+0300</tbml:value>
+          </tbml:option>
+          <!-- $ TZ=Europe/Moscow date -d @1529420400 +%Y%m%d%H%M%S%z -->
+          <tbml:option key="1529420400">
+            <tbml:value>20180619180000+0300</tbml:value>
+          </tbml:option>
+          <!-- $ TZ=Europe/Moscow date -d @1529431200 +%Y%m%d%H%M%S%z -->
+          <tbml:option key="1529431200">
+            <tbml:value>20180619210000+0300</tbml:value>
+          </tbml:option>
+          <!-- $ TZ=Europe/Moscow date -d @1530900000 +%Y%m%d%H%M%S%z -->
+          <tbml:option key="1530900000">
+            <tbml:value>20180706210000+0300</tbml:value>
+          </tbml:option>
+          <!-- $ TZ=Europe/Moscow date -d @1531576800 +%Y%m%d%H%M%S%z -->
+          <tbml:option key="1531576800">
+            <tbml:value>20180714170000+0300</tbml:value>
+          </tbml:option>
+          <tbml:option key="1536778800">
+            <tbml:value>20180911190000+0800</tbml:value>
+          </tbml:option>
+          <tbml:option key="1536692400">
+            <tbml:value>20180911190000+0800</tbml:value>
+          </tbml:option>
+        </tbml:mapping>
         <!-- For RISE conference in Hong Kong. The key is not UnixTime as UnixTime should be 1531299600
          $ TZ=Asia/Hong_Kong date -d @1531299600 +%Y%m%d%H%M%S%z
          20180711170000+0800-->
@@ -572,146 +578,148 @@
       <tbml:name lang="zh">等级</tbml:name>
       <tbml:name lang="es">Cat</tbml:name>
       <tbml:origin bitmask="0000000000000000000000000000000000000000000000000000000000FF0000" as="mapping">
-        <tbml:option key="1">
-          <tbml:value lang="en">Category 1</tbml:value>
-          <tbml:value lang="zh">一类票</tbml:value>
-        </tbml:option>
-        <tbml:option key="2">
-          <tbml:value lang="en">Category 2</tbml:value>
-          <tbml:value lang="zh">二类票</tbml:value>
-        </tbml:option>
-        <tbml:option key="3">
-          <tbml:value lang="en">Category 3</tbml:value>s
-          <tbml:value lang="zh">三类票</tbml:value>
-        </tbml:option>
-        <tbml:option key="4">
-          <tbml:value lang="en">Category 4</tbml:value>
-          <tbml:value lang="zh">四类票</tbml:value>
-        </tbml:option>
-        <tbml:option key="5">
-          <tbml:value lang="en">Match Club</tbml:value>
-          <tbml:value lang="zh">俱乐部坐席</tbml:value>
-        </tbml:option>
-        <tbml:option key="6">
-          <tbml:value lang="en">Match House Premier</tbml:value>
-          <tbml:value lang="zh">比赛之家坐席</tbml:value>
-        </tbml:option>
-        <tbml:option key="7">
-          <tbml:value lang="en">MATCH PAVILION</tbml:value>
-          <tbml:value lang="zh">款待大厅坐席</tbml:value>
-        </tbml:option>
-        <tbml:option key="8">
-          <tbml:value lang="en">MATCH BUSINESS SEAT</tbml:value>
-          <tbml:value lang="zh">商务坐席</tbml:value>
-        </tbml:option>
-        <tbml:option key="9">
-          <tbml:value lang="en">MATCH SHARED SUITE</tbml:value>
-          <tbml:value lang="zh">公共包厢</tbml:value>
-        </tbml:option>
-        <tbml:option key="10">
-          <tbml:value lang="en">TSARSKY LOUNGE</tbml:value>
-          <tbml:value lang="zh">特拉斯基豪华包厢</tbml:value>
-        </tbml:option>
-        <tbml:option key="11">
-          <tbml:value lang="en">MATCH PRIVATE SUITE</tbml:value>
-          <tbml:value lang="zh">私人包厢</tbml:value>
-        </tbml:option>
-        <tbml:option key="255">
-          <tbml:value lang="en">Singapore Blockchain Event</tbml:value>
-          <tbml:value lang="zh">新加坡区块链活动</tbml:value>
-        </tbml:option>
-        <tbml:option key="254">
-          <tbml:value lang="en">TECHNOLOGY RADAR SUMMIT 2018</tbml:value>
-          <tbml:value lang="zh">技术雷达峰会2018</tbml:value>
-        </tbml:option>
-        <tbml:option key="253">
-          <tbml:value lang="en">Sydney Blockchain Event</tbml:value>
-          <tbml:value lang="zh">悉尼区块链活动</tbml:value>
-        </tbml:option>
-        <tbml:option key="252">
-          <tbml:value lang="en">Beijing Blockchain Event</tbml:value>
-          <tbml:value lang="zh">北京区块链活动</tbml:value>
-        </tbml:option>
-        <tbml:option key="251">
-          <tbml:value lang="en">Shanghai Blockchain Event</tbml:value>
-          <tbml:value lang="zh">上海区块链活动</tbml:value>
-        </tbml:option>
-        <tbml:option key="250">
-          <tbml:value lang="en">Tokyo Blockchain Event</tbml:value>
-          <tbml:value lang="zh">东京区块链活动</tbml:value>
-        </tbml:option>
-        <tbml:option key="249">
-          <tbml:value lang="en">Blockchain Event</tbml:value>
-          <tbml:value lang="zh">区块链活动</tbml:value>
-        </tbml:option>
-        <tbml:option key="248">
-          <tbml:value lang="en">Other Events</tbml:value>
-          <tbml:value lang="zh">其他活动</tbml:value>
-        </tbml:option>
-        <tbml:option key="247">
-          <tbml:value lang="en">Seoul Blockchain Event</tbml:value>
-          <tbml:value lang="zh">首尔区块链活动</tbml:value>
-        </tbml:option>
-        <tbml:option key="246">
-          <tbml:value lang="en">Bangkok Blockchain Event</tbml:value>
-          <tbml:value lang="zh">曼谷区块链活动</tbml:value>
-        </tbml:option>
-        <tbml:option key="245">
-          <tbml:value lang="en">AlphaWallet Event</tbml:value>
-          <tbml:value lang="zh">AlphaWallet活动</tbml:value>
-        </tbml:option>
-        <tbml:option key="243">
-          <tbml:value lang="en">Stormbird Event</tbml:value>
-          <tbml:value lang="zh">Stormbird活动</tbml:value>
-        </tbml:option>
-        <tbml:option key="242">
-          <tbml:value lang="en">UNITY VENTURES Event</tbml:value>
-          <tbml:value lang="zh">九合创投活动</tbml:value>
-        </tbml:option>
-        <tbml:option key="241">
-          <tbml:value lang="en">Max's Event</tbml:value>
-          <tbml:value lang="zh">Max的活动</tbml:value>
-        </tbml:option>
-        <tbml:option key="240">
-          <tbml:value lang="en">Chongqing Blockchain Event</tbml:value>
-          <tbml:value lang="zh">重庆区块链活动</tbml:value>
-        </tbml:option>
-        <tbml:option key="239">
-          <tbml:value lang="en">Dubai Blockchain Event</tbml:value>
-          <tbml:value lang="zh">迪拜区块链活动</tbml:value>
-        </tbml:option>
-        <tbml:option key="238">
-          <tbml:value lang="en">Silicon Valley Blockchain Event</tbml:value>
-          <tbml:value lang="zh">硅谷区块链活动</tbml:value>
-        </tbml:option>
-        <tbml:option key="237">
-          <tbml:value lang="en">Melbourne Blockchain Event</tbml:value>
-          <tbml:value lang="zh">墨尔本区块链活动</tbml:value>
-        </tbml:option>
-        <tbml:option key="236">
-          <tbml:value lang="en">General Event</tbml:value>
-          <tbml:value lang="zh">通用活动</tbml:value>
-        </tbml:option>
-        <tbml:option key="235">
-          <tbml:value lang="en">AlphaWallet Meeting Slot</tbml:value>
-          <tbml:value lang="zh">AlphaWallet面议机会</tbml:value>
-        </tbml:option>
-        <tbml:option key="234">
-          <tbml:value lang="en">ERC875 Meetup</tbml:value>
-          <tbml:value lang="zh">ERC875线下聚会</tbml:value>
-        </tbml:option>
-        <tbml:option key="144">
-          <tbml:value lang="en">Nervos and AlphaWallet Meetup</tbml:value>
-          <tbml:value lang="zh">Nervos和AlphaWallet见面会</tbml:value>
-        </tbml:option>
-        <tbml:option key="233">
-          <tbml:value lang="en">AlphaWallet and our friends</tbml:value>
-          <tbml:value lang="zh">AlphaWallet和小伙伴们</tbml:value>
-        </tbml:option>
-        <tbml:option key="232">
-          <tbml:value lang="en">The Future of LAYER 2: Prague Edition</tbml:value>
-          <tbml:value lang="zh">The Future of LAYER 2: Prague Edition</tbml:value>
-        </tbml:option>        
+        <tbml:mapping>
+          <tbml:option key="1">
+            <tbml:value lang="en">Category 1</tbml:value>
+            <tbml:value lang="zh">一类票</tbml:value>
+          </tbml:option>
+          <tbml:option key="2">
+            <tbml:value lang="en">Category 2</tbml:value>
+            <tbml:value lang="zh">二类票</tbml:value>
+          </tbml:option>
+          <tbml:option key="3">
+            <tbml:value lang="en">Category 3</tbml:value>s
+            <tbml:value lang="zh">三类票</tbml:value>
+          </tbml:option>
+          <tbml:option key="4">
+            <tbml:value lang="en">Category 4</tbml:value>
+            <tbml:value lang="zh">四类票</tbml:value>
+          </tbml:option>
+          <tbml:option key="5">
+            <tbml:value lang="en">Match Club</tbml:value>
+            <tbml:value lang="zh">俱乐部坐席</tbml:value>
+          </tbml:option>
+          <tbml:option key="6">
+            <tbml:value lang="en">Match House Premier</tbml:value>
+            <tbml:value lang="zh">比赛之家坐席</tbml:value>
+          </tbml:option>
+          <tbml:option key="7">
+            <tbml:value lang="en">MATCH PAVILION</tbml:value>
+            <tbml:value lang="zh">款待大厅坐席</tbml:value>
+          </tbml:option>
+          <tbml:option key="8">
+            <tbml:value lang="en">MATCH BUSINESS SEAT</tbml:value>
+            <tbml:value lang="zh">商务坐席</tbml:value>
+          </tbml:option>
+          <tbml:option key="9">
+            <tbml:value lang="en">MATCH SHARED SUITE</tbml:value>
+            <tbml:value lang="zh">公共包厢</tbml:value>
+          </tbml:option>
+          <tbml:option key="10">
+            <tbml:value lang="en">TSARSKY LOUNGE</tbml:value>
+            <tbml:value lang="zh">特拉斯基豪华包厢</tbml:value>
+          </tbml:option>
+          <tbml:option key="11">
+            <tbml:value lang="en">MATCH PRIVATE SUITE</tbml:value>
+            <tbml:value lang="zh">私人包厢</tbml:value>
+          </tbml:option>
+          <tbml:option key="255">
+            <tbml:value lang="en">Singapore Blockchain Event</tbml:value>
+            <tbml:value lang="zh">新加坡区块链活动</tbml:value>
+          </tbml:option>
+          <tbml:option key="254">
+            <tbml:value lang="en">TECHNOLOGY RADAR SUMMIT 2018</tbml:value>
+            <tbml:value lang="zh">技术雷达峰会2018</tbml:value>
+          </tbml:option>
+          <tbml:option key="253">
+            <tbml:value lang="en">Sydney Blockchain Event</tbml:value>
+            <tbml:value lang="zh">悉尼区块链活动</tbml:value>
+          </tbml:option>
+          <tbml:option key="252">
+            <tbml:value lang="en">Beijing Blockchain Event</tbml:value>
+            <tbml:value lang="zh">北京区块链活动</tbml:value>
+          </tbml:option>
+          <tbml:option key="251">
+            <tbml:value lang="en">Shanghai Blockchain Event</tbml:value>
+            <tbml:value lang="zh">上海区块链活动</tbml:value>
+          </tbml:option>
+          <tbml:option key="250">
+            <tbml:value lang="en">Tokyo Blockchain Event</tbml:value>
+            <tbml:value lang="zh">东京区块链活动</tbml:value>
+          </tbml:option>
+          <tbml:option key="249">
+            <tbml:value lang="en">Blockchain Event</tbml:value>
+            <tbml:value lang="zh">区块链活动</tbml:value>
+          </tbml:option>
+          <tbml:option key="248">
+            <tbml:value lang="en">Other Events</tbml:value>
+            <tbml:value lang="zh">其他活动</tbml:value>
+          </tbml:option>
+          <tbml:option key="247">
+            <tbml:value lang="en">Seoul Blockchain Event</tbml:value>
+            <tbml:value lang="zh">首尔区块链活动</tbml:value>
+          </tbml:option>
+          <tbml:option key="246">
+            <tbml:value lang="en">Bangkok Blockchain Event</tbml:value>
+            <tbml:value lang="zh">曼谷区块链活动</tbml:value>
+          </tbml:option>
+          <tbml:option key="245">
+            <tbml:value lang="en">AlphaWallet Event</tbml:value>
+            <tbml:value lang="zh">AlphaWallet活动</tbml:value>
+          </tbml:option>
+          <tbml:option key="243">
+            <tbml:value lang="en">Stormbird Event</tbml:value>
+            <tbml:value lang="zh">Stormbird活动</tbml:value>
+          </tbml:option>
+          <tbml:option key="242">
+            <tbml:value lang="en">UNITY VENTURES Event</tbml:value>
+            <tbml:value lang="zh">九合创投活动</tbml:value>
+          </tbml:option>
+          <tbml:option key="241">
+            <tbml:value lang="en">Max's Event</tbml:value>
+            <tbml:value lang="zh">Max的活动</tbml:value>
+          </tbml:option>
+          <tbml:option key="240">
+            <tbml:value lang="en">Chongqing Blockchain Event</tbml:value>
+            <tbml:value lang="zh">重庆区块链活动</tbml:value>
+          </tbml:option>
+          <tbml:option key="239">
+            <tbml:value lang="en">Dubai Blockchain Event</tbml:value>
+            <tbml:value lang="zh">迪拜区块链活动</tbml:value>
+          </tbml:option>
+          <tbml:option key="238">
+            <tbml:value lang="en">Silicon Valley Blockchain Event</tbml:value>
+            <tbml:value lang="zh">硅谷区块链活动</tbml:value>
+          </tbml:option>
+          <tbml:option key="237">
+            <tbml:value lang="en">Melbourne Blockchain Event</tbml:value>
+            <tbml:value lang="zh">墨尔本区块链活动</tbml:value>
+          </tbml:option>
+          <tbml:option key="236">
+            <tbml:value lang="en">General Event</tbml:value>
+            <tbml:value lang="zh">通用活动</tbml:value>
+          </tbml:option>
+          <tbml:option key="235">
+            <tbml:value lang="en">AlphaWallet Meeting Slot</tbml:value>
+            <tbml:value lang="zh">AlphaWallet面议机会</tbml:value>
+          </tbml:option>
+          <tbml:option key="234">
+            <tbml:value lang="en">ERC875 Meetup</tbml:value>
+            <tbml:value lang="zh">ERC875线下聚会</tbml:value>
+          </tbml:option>
+          <tbml:option key="144">
+            <tbml:value lang="en">Nervos and AlphaWallet Meetup</tbml:value>
+            <tbml:value lang="zh">Nervos和AlphaWallet见面会</tbml:value>
+          </tbml:option>
+          <tbml:option key="233">
+            <tbml:value lang="en">AlphaWallet and our friends</tbml:value>
+            <tbml:value lang="zh">AlphaWallet和小伙伴们</tbml:value>
+          </tbml:option>
+          <tbml:option key="232">
+            <tbml:value lang="en">The Future of LAYER 2: Prague Edition</tbml:value>
+            <tbml:value lang="zh">The Future of LAYER 2: Prague Edition</tbml:value>
+          </tbml:option>
+        </tbml:mapping>
       </tbml:origin>
     </tbml:attribute-type>
     <tbml:attribute-type id="numero" syntax="1.3.6.1.4.1.1466.115.121.1.27">

--- a/blockchain-tickets/schema1/blockchain-events-china.xml
+++ b/blockchain-tickets/schema1/blockchain-events-china.xml
@@ -172,7 +172,7 @@
       <tbml:name lang="zh">城市</tbml:name>
       <tbml:name lang="es">Ciudad</tbml:name>
       <tbml:name lang="ru">город</tbml:name>
-      <tbml:origin as="mapping" bitmask="00000000000000000000000000000000FF000000000000000000000000000000">
+      <tbml:origin bitmask="00000000000000000000000000000000FF000000000000000000000000000000" as="mapping">
         <tbml:option key="1">
           <tbml:value lang="ru">Москва́</tbml:value>
           <tbml:value lang="en">Moscow</tbml:value>
@@ -350,7 +350,7 @@
       <tbml:name lang="zh">场馆</tbml:name>
       <tbml:name lang="es">Lugar</tbml:name>
       <tbml:name lang="ru">место встречи</tbml:name>
-      <tbml:origin as="mapping" bitmask="0000000000000000000000000000000000FF0000000000000000000000000000">
+      <tbml:origin bitmask="0000000000000000000000000000000000FF0000000000000000000000000000" as="mapping">
         <tbml:option key="1">
           <tbml:value lang="ru">Стадион Калининград</tbml:value>
           <tbml:value lang="en">Kaliningrad Stadium</tbml:value>
@@ -506,7 +506,7 @@
       <tbml:name lang="ru">время</tbml:name>
       <!-- keys used here are BinaryTime (RFC6019) for backward compatibility,
            don't copy this behaviour when creating new assets -->
-      <tbml:origin as="mapping" bitmask="000000000000000000000000000000000000FFFFFFFF00000000000000000000">
+      <tbml:origin bitmask="000000000000000000000000000000000000FFFFFFFF00000000000000000000" as="mapping">
         <!-- $ TZ=Europe/Moscow date -d @1528988400 +%Y%m%d%H%M%S%z -->
         <tbml:option key="1528988400">
           <tbml:value>20180614180000+0300</tbml:value>
@@ -553,25 +553,25 @@
       <tbml:name lang="en">Team A</tbml:name>
       <tbml:name lang="zh">甲队</tbml:name>
       <tbml:name lang="es">Equipo A</tbml:name>
-      <tbml:origin as="utf8" bitmask="00000000000000000000000000000000000000000000FFFFFF00000000000000"/>
+      <tbml:origin bitmask="00000000000000000000000000000000000000000000FFFFFF00000000000000" as="utf8"/>
     </tbml:attribute-type>
     <tbml:attribute-type id="countryB" syntax="1.3.6.1.4.1.1466.115.121.1.26">
       <tbml:name lang="en">Team B</tbml:name>
       <tbml:name lang="zh">乙队</tbml:name>
       <tbml:name lang="es">Equipo B</tbml:name>
-      <tbml:origin as="utf8" bitmask="00000000000000000000000000000000000000000000000000FFFFFF00000000"/>
+      <tbml:origin bitmask="00000000000000000000000000000000000000000000000000FFFFFF00000000" as="utf8"/>
     </tbml:attribute-type>
     <tbml:attribute-type id="match" syntax="1.3.6.1.4.1.1466.115.121.1.27">
       <tbml:name lang="en">Match</tbml:name>
       <tbml:name lang="zh">场次</tbml:name>
       <tbml:name lang="es">Evento</tbml:name>
-      <tbml:origin as="unsigned" bitmask="00000000000000000000000000000000000000000000000000000000FF000000"/>
+      <tbml:origin bitmask="00000000000000000000000000000000000000000000000000000000FF000000" as="unsigned"/>
     </tbml:attribute-type>
     <tbml:attribute-type id="category" syntax="1.3.6.1.4.1.1466.115.121.1.15">
       <tbml:name lang="en">Cat</tbml:name>
       <tbml:name lang="zh">等级</tbml:name>
       <tbml:name lang="es">Cat</tbml:name>
-      <tbml:origin as="mapping" bitmask="0000000000000000000000000000000000000000000000000000000000FF0000">
+      <tbml:origin bitmask="0000000000000000000000000000000000000000000000000000000000FF0000" as="mapping">
         <tbml:option key="1">
           <tbml:value lang="en">Category 1</tbml:value>
           <tbml:value lang="zh">一类票</tbml:value>
@@ -716,7 +716,7 @@
     </tbml:attribute-type>
     <tbml:attribute-type id="numero" syntax="1.3.6.1.4.1.1466.115.121.1.27">
       <tbml:name>№</tbml:name>
-      <tbml:origin as="unsigned" bitmask="000000000000000000000000000000000000000000000000000000000000FFFF"/>
+      <tbml:origin bitmask="000000000000000000000000000000000000000000000000000000000000FFFF" as="unsigned"/>
     </tbml:attribute-type>
   </tbml:attribute-types>
 </tbml:token>

--- a/spawnable-contract/schema1/MeetupContract.xml
+++ b/spawnable-contract/schema1/MeetupContract.xml
@@ -158,8 +158,8 @@
       <tb:name lang="zh">区号</tb:name>
       <tb:origin bitmask="000000000000000000000000000000000000000000000000000000FFFFFFFFFF" as="utf8"/>
     </tb:attribute-type>
-    <tb:attribute-type id="expired" syntax="1.3.6.1.4.1.1466.115.121.1.7" as="mapping"> <!-- boolean -->
-      <tb:origin contract="holding-contract">
+    <tb:attribute-type id="expired" syntax="1.3.6.1.4.1.1466.115.121.1.7"> <!-- boolean -->
+      <tb:origin contract="holding-contract" as="mapping">
         <tb:function name="isExpired">
           <tb:inputs>
             <tb:uint256 ref="tokenID"/>

--- a/spawnable-contract/schema1/MeetupContract.xml
+++ b/spawnable-contract/schema1/MeetupContract.xml
@@ -158,7 +158,7 @@
       <tb:name lang="zh">区号</tb:name>
       <tb:origin bitmask="000000000000000000000000000000000000000000000000000000FFFFFFFFFF" as="utf8"/>
     </tb:attribute-type>
-    <tb:attribute-type id="expired" syntax="1.3.6.1.4.1.1466.115.121.1.7"> <!-- boolean -->
+    <tb:attribute-type id="expired" syntax="1.3.6.1.4.1.1466.115.121.1.7" as="mapping"> <!-- boolean -->
       <tb:origin contract="holding-contract">
         <tb:function contract="holding-contract" name="isExpired">
           <tb:inputs>
@@ -166,8 +166,12 @@
           </tb:inputs>
         </tb:function>
       </tb:origin>
+      <tb:mapping>
+        <option key="0">FALSE</option>
+        <option key="1">TRUE</option>
+      </tb:mapping>
     </tb:attribute-type>
-    <tb:attribute-type id="street" syntax="1.3.6.1.4.1.1466.115.121.1.15"> <!-- string -->
+    <tb:attribute-type id="street" syntax="1.3.6.1.4.1.1466.115.121.1.15" as="utf8"> <!-- string -->
       <tb:origin contract="holding-contract">
         <tb:function name="getStreet">
           <tb:inputs>
@@ -176,7 +180,7 @@
         </tb:function>
       </tb:origin>
     </tb:attribute-type>
-    <tb:attribute-type id="building" syntax="1.3.6.1.4.1.1466.115.121.1.15"> <!-- string -->
+    <tb:attribute-type id="building" syntax="1.3.6.1.4.1.1466.115.121.1.15" as="utf8"> <!-- string -->
       <tb:origin contract="holding-contract">
         <tb:function name="getBuildingName">
           <tb:inputs>
@@ -185,7 +189,7 @@
         </tb:function>
       </tb:origin>
     </tb:attribute-type>
-    <tb:attribute-type id="state" syntax="1.3.6.1.4.1.1466.115.121.1.15"> <!-- string -->
+    <tb:attribute-type id="state" syntax="1.3.6.1.4.1.1466.115.121.1.15" as="utf8"> <!-- string -->
       <tb:origin contract="holding-contract">
         <tb:function name="getState">
           <tb:inputs>

--- a/spawnable-contract/schema1/MeetupContract.xml
+++ b/spawnable-contract/schema1/MeetupContract.xml
@@ -167,8 +167,8 @@
         </tb:function>
       </tb:origin>
       <tb:mapping>
-        <option key="0">FALSE</option>
-        <option key="1">TRUE</option>
+        <tb:option key="0">FALSE</tb:option>
+        <tb:option key="1">TRUE</tb:option>
       </tb:mapping>
     </tb:attribute-type>
     <tb:attribute-type id="street" syntax="1.3.6.1.4.1.1466.115.121.1.15" as="utf8"> <!-- string -->

--- a/spawnable-contract/schema1/MeetupContract.xml
+++ b/spawnable-contract/schema1/MeetupContract.xml
@@ -160,7 +160,7 @@
     </tb:attribute-type>
     <tb:attribute-type id="expired" syntax="1.3.6.1.4.1.1466.115.121.1.7" as="mapping"> <!-- boolean -->
       <tb:origin contract="holding-contract">
-        <tb:function contract="holding-contract" name="isExpired">
+        <tb:function name="isExpired">
           <tb:inputs>
             <tb:uint256 ref="tokenID"/>
           </tb:inputs>

--- a/spawnable-contract/schema1/MeetupContract.xml
+++ b/spawnable-contract/schema1/MeetupContract.xml
@@ -122,43 +122,10 @@
 
   <!-- token UI definition can happen here -->
   <tb:attribute-types>
-    <!--
-
-    Information about a meetup, like Country, City, time,
-	can all be looked up by tokenID. There are
-    advantages and disadvantages in encoding them by a look up table
-    or by a bit field.
-
-    The advantage of storing them as a bit field is that one can
-    enquiry the range of it in the market queue server without the
-    server kowing the meaning of the bitfields. Furthermore it make
-    the android and ios library which accesses the XML file a bit
-    easier to write, but at the cost that the ticket issuing
-    (authorisation) server is a bit more complicated.
-
-    For now we decide to use bit-fields.  The fields, together with
-    its bitwidth or byte-width are represented in this table:
-
-    country	  		 FF00000000000000000000000000000000000000000000000000000000000000
-	locality 1 byte	 FF00000000000000000000000000000000000000000000000000000000000000
-	time	 19 byte 00FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF000000000000000000000000
-	numero	 2 byte  0000000000000000000000000000000000000000FFFF00000000000000000000
-	category 5 byte  00000000000000000000000000000000000000000000FFFFFFFFFF0000000000
-	section	 5 byte  000000000000000000000000000000000000000000000000000000FFFFFFFFFF
-
-    In practise, because this XML file is used in 3 to 4 places
-    (authorisation server, ios, android, potentially market-queue),
-    Weiwu thought that it helps the developers if we use byte-fields
-    instead of bit-fields.
-    1.3.6.1.4.1.1466.115.121.1.15 is DirectoryString
-    1.3.6.1.4.1.1466.115.121.1.24 is GeneralisedTime
-    1.3.6.1.4.1.1466.115.121.1.26 is IA5String
-    1.3.6.1.4.1.1466.115.121.1.27 is Integer
-  -->
     <tb:attribute-type id="country" oid="2.5.4.7" syntax="1.3.6.1.4.1.1466.115.121.1.15">
       <tb:name lang="en">Country</tb:name>
       <tb:name lang="zh">国家</tb:name>
-      <tb:origin as="utf8" bitmask="FFFF000000000000000000000000000000000000000000000000000000000000"/>
+      <tb:origin bitmask="FFFF000000000000000000000000000000000000000000000000000000000000" as="utf8"/>
     </tb:attribute-type>
     <tb:attribute-type id="locality" oid="2.5.4.7" syntax="1.3.6.1.4.1.1466.115.121.1.15">
       <tb:name lang="en">City</tb:name>
@@ -174,44 +141,44 @@
     <tb:attribute-type id="time" syntax="1.3.6.1.4.1.1466.115.121.1.24">
       <tb:name lang="en">Time</tb:name>
       <tb:name lang="zh">时间</tb:name>
-      <tb:origin as="utf8" bitmask="00FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF000000000000000000000000"/>
+      <tb:origin bitmask="00FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF000000000000000000000000" as="utf8"/>
     </tb:attribute-type>
     <tb:attribute-type id="numero" syntax="1.3.6.1.4.1.1466.115.121.1.27">
       <tb:name lang="en">No</tb:name>
       <tb:name lang="zh">票号</tb:name>
-      <tb:origin as="unsigned" bitmask="0000000000000000000000000000000000000000FFFF00000000000000000000"/>
+      <tb:origin bitmask="0000000000000000000000000000000000000000FFFF00000000000000000000" as="unsigned"/>
     </tb:attribute-type>
     <tb:attribute-type id="category" syntax="1.3.6.1.4.1.1466.115.121.1.15">
       <tb:name lang="en">Cat</tb:name>
       <tb:name lang="zh">等级</tb:name>
-      <tb:origin as="utf8" bitmask="00000000000000000000000000000000000000000000FFFFFFFFFF0000000000"/>
+      <tb:origin bitmask="00000000000000000000000000000000000000000000FFFFFFFFFF0000000000" as="utf8"/>
     </tb:attribute-type>
     <tb:attribute-type id="section" syntax="1.3.6.1.4.1.1466.115.121.1.15">
       <tb:name lang="en">Section</tb:name>
       <tb:name lang="zh">区号</tb:name>
-      <tb:origin as="utf8" bitmask="000000000000000000000000000000000000000000000000000000FFFFFFFFFF"/>
+      <tb:origin bitmask="000000000000000000000000000000000000000000000000000000FFFFFFFFFF" as="utf8"/>
     </tb:attribute-type>
     <tb:attribute-type id="expired" syntax="1.3.6.1.4.1.1466.115.121.1.7"> <!-- boolean -->
-      <tb:value-sourcing>
+      <tb:origin contract="holding-contract">
         <tb:function contract="holding-contract" name="isExpired">
           <tb:inputs>
             <tb:uint256 ref="tokenID"/>
           </tb:inputs>
         </tb:function>
-      </tb:value-sourcing>
+      </tb:origin>
     </tb:attribute-type>
     <tb:attribute-type id="street" syntax="1.3.6.1.4.1.1466.115.121.1.15"> <!-- string -->
-      <tb:value-sourcing>
-        <tb:function contract="holding-contract" name="getStreet">
+      <tb:origin contract="holding-contract">
+        <tb:function name="getStreet">
           <tb:inputs>
             <tb:uint256 ref="tokenID"/>
           </tb:inputs>
         </tb:function>
-      </tb:value-sourcing>
+      </tb:origin>
     </tb:attribute-type>
     <tb:attribute-type id="building" syntax="1.3.6.1.4.1.1466.115.121.1.15"> <!-- string -->
       <tb:origin contract="holding-contract">
-        <tb:function contract="holding-contract" name="getBuildingName">
+        <tb:function name="getBuildingName">
           <tb:inputs>
             <tb:uint256 ref="tokenID"/>
           </tb:inputs>

--- a/spawnable-contract/schema1/MeetupContract.xml
+++ b/spawnable-contract/schema1/MeetupContract.xml
@@ -165,11 +165,15 @@
             <tb:uint256 ref="tokenID"/>
           </tb:inputs>
         </tb:function>
+        <tb:mapping>
+          <tb:option key="0">
+            <tb:value>FALSE</tb:value>
+          </tb:option>
+          <tb:option key="1">
+            <tb:value>TRUE</tb:value>
+          </tb:option>
+        </tb:mapping>
       </tb:origin>
-      <tb:mapping>
-        <tb:option key="0">FALSE</tb:option>
-        <tb:option key="1">TRUE</tb:option>
-      </tb:mapping>
     </tb:attribute-type>
     <tb:attribute-type id="street" syntax="1.3.6.1.4.1.1466.115.121.1.15" as="utf8"> <!-- string -->
       <tb:origin contract="holding-contract">


### PR DESCRIPTION
This was intended to finally close #70 

- adding <mapping> element (this is likely to break existing code)
- utilise Boon's comment on https://github.com/AlphaWallet/contracts/issues/70 to address multi-origin values
- delete irrelevant comments
- apply this to all xml:

    `$ sed -i 's$\(as="[^"]*"\) \(bitmask="[^"]*"\)$\2 \1$'`