### PR TITLE
Remove 'view' from active setter functions

### DIFF
--- a/spawnable-contract/schema1/MeetupContract.sol
+++ b/spawnable-contract/schema1/MeetupContract.sol
@@ -112,22 +112,22 @@ contract Meetup
         expired = isExpired;
     }
 
-    function setStreet(uint256[] tokenIds, string newStreet) public view organiserOnly returns(string)
+    function setStreet(uint256[] tokenIds, string newStreet) public organiserOnly returns(string)
     {
         street = newStreet;
     }
 
-    function setBuilding(uint256[] tokenIds, string newBuildingName) public view organiserOnly returns(string)
+    function setBuilding(uint256[] tokenIds, string newBuildingName) public organiserOnly returns(string)
     {
         building = newBuildingName;
     }
 
-    function setState(uint256[] tokenIds, string newState) public view organiserOnly returns(string)
+    function setState(uint256[] tokenIds, string newState) public organiserOnly returns(string)
     {
         state = newState;
     }
 
-    function setLocality(uint256[] tokenIds, string newLocality) public view organiserOnly returns(string)
+    function setLocality(uint256[] tokenIds, string newLocality) public organiserOnly returns(string)
     {
         locality = newLocality;
     }


### PR DESCRIPTION
The setter functions shouldn't have the 'view' modifier. Its not too important since you can force change the values through pushing a transaction through web3j but technically you shouldn't have those modifiers.

Remix won't allow you to update the values with that modifier, which is why I found it. It doesn't change the signature so it wouldn't affect web3j.