### PR TITLE
comply to magiclink spec

### DIFF
--- a/spawnable-contract/schema1/MeetupContract.sol
+++ b/spawnable-contract/schema1/MeetupContract.sol
@@ -261,22 +261,22 @@ contract Meetup
     function encodeMessageSpawnable(uint value, uint expiry, uint256[] tickets)
         internal view returns (bytes32)
     {
-        bytes memory message = new bytes(84 + tickets.length * 32);
+        bytes memory message = new bytes(28 + tickets.length * 32);
         address contractAddress = getThisContractAddress();
-        for (uint i = 0; i < 32; i++)
+        for (uint i = 0; i < 4; i++)
         {   // convert bytes32 to bytes[32]
             // this adds the price to the message
-            message[i] = byte(value << (8 * i));
+            message[i] = byte(bytes4(value << (8 * i)));
         }
 
-        for (i = 0; i < 32; i++)
+        for (i = 0; i < 4; i++)
         {
-            message[i + 32] = byte(expiry << (8 * i));
+            message[i + 4] = byte(bytes4(expiry << (8 * i)));
         }
 
         for(i = 0; i < 20; i++)
         {
-            message[64 + i] = byte(bytes20(contractAddress) << (8 * i));
+            message[8 + i] = byte(bytes20(contractAddress) << (8 * i));
         }
 
         for (i = 0; i < tickets.length; i++)
@@ -284,7 +284,7 @@ contract Meetup
             // convert uint256[] to bytes
             for (uint j = 0; j < 32; j++)
             {
-                message[84 + i * 32 + j] = byte(tickets[i] << (8 * j));
+                message[28 + i * 32 + j] = byte(bytes32(tickets[i] << (8*j)));
             }
         }
         return keccak256(message);


### PR DESCRIPTION
4 bytes not 32 bytes for the Price and Expire in encodeMessageSpawnable() based on spec https://github.com/lyhistory/Peter-s-Tool/issues/15