### PR TITLE
add NativeCryptoDispensary.sol for magic links which drop the native currency

### DIFF
--- a/spawnable-contract/currency-links/NativeCryptoDispensary.sol
+++ b/spawnable-contract/currency-links/NativeCryptoDispensary.sol
@@ -1,9 +1,10 @@
 //magic link encoding 0x04
-//send dai to this contract and use the contract balance to move the funds
+//send any native currency to this contract and use the contract balance to move the funds
+//Ropsten: 0x9d928a678eeaaEfA19eF73E5368830b3476C0678
 pragma solidity 0.5.1;
 contract NativeCryptoDispensary {
 
-    string public requiredPrefix = "XDAIDROP";
+    bytes8 public requiredPrefix = "XDAIDROP";
     address payable approvedSigner;
     uint[] nonces;
     address approvedPaymaster;
@@ -13,23 +14,54 @@ contract NativeCryptoDispensary {
         approvedSigner = signer;
     }
     
+    function() payable external {
+        //allow deposits
+        require(msg.sender == approvedPaymaster);
+    }
+    
     function dropCurrency(
-        uint nonce, 
-        uint amount,
-        uint expiry,
+        uint32 nonce, 
+        uint32 amount,
+        uint32 expiry,
         uint8 v,
         bytes32 r,
         bytes32 s,
-        address payable reciever
+        address payable receiver
     ) public {
         //stop people from stealing drops by enforcing a paymaster to use it
         require(msg.sender == approvedPaymaster);
         require(block.timestamp < expiry);
         checkIfNonceUsed(nonce);
-        bytes32 message = keccak256(abi.encodePacked(requiredPrefix, nonce, amount, expiry, this));
+        //message is signed with szabo price 
+        bytes32 message = formMessage(nonce, amount, expiry, address(this));
         require(ecrecover(message, v, r, s) == approvedSigner);
         //price is signed as szabo units 
-        reciever.transfer(amount * (1 szabo));
+        receiver.transfer(amount * (1 szabo));
+    }
+    
+    function formMessage(
+        uint32 nonce, 
+        uint32 amount,
+        uint32 expiry, 
+        address contractAddress
+    ) internal view returns(bytes32) {
+        bytes memory message = new bytes(40);
+        for(uint i = 0; i < 8; i++) {
+            message[i] = byte(bytes8(requiredPrefix << (8 * i)));
+        }
+        for(uint i = 0; i < 4; i++) {
+            message[i + 8] = byte(bytes4(nonce << (8 * i)));
+        }
+        for(uint i = 0; i < 4; i++) {
+            message[i + 12] = byte(bytes4(amount << (8 * i)));
+        }
+        for(uint i = 0; i < 4; i++) {
+            message[i + 16] = byte(bytes4(expiry << (8 * i)));
+        }
+        for(uint i = 0; i < 20; i++) {
+            message[i + 20] = byte(bytes20(bytes20(contractAddress) << (8 * i)));
+        }
+        return keccak256(message);
     }
     
     function checkIfNonceUsed(uint nonce) internal view {

--- a/spawnable-contract/currency-links/NativeCryptoDispensary.sol
+++ b/spawnable-contract/currency-links/NativeCryptoDispensary.sol
@@ -1,0 +1,48 @@
+//magic link encoding 0x04
+//send dai to this contract and use the contract balance to move the funds
+pragma solidity 0.5.1;
+contract NativeCryptoDispensary {
+
+    string public requiredPrefix = "XDAIDROP";
+    address payable approvedSigner;
+    uint[] nonces;
+    address approvedPaymaster;
+    
+    constructor(address paymaster, address payable signer) public {
+        approvedPaymaster = paymaster;
+        approvedSigner = signer;
+    }
+    
+    function dropCurrency(
+        uint nonce, 
+        uint amount,
+        uint expiry,
+        uint8 v,
+        bytes32 r,
+        bytes32 s,
+        address payable reciever
+    ) public {
+        //stop people from stealing drops by enforcing a paymaster to use it
+        require(msg.sender == approvedPaymaster);
+        require(block.timestamp < expiry);
+        checkIfNonceUsed(nonce);
+        bytes32 message = keccak256(abi.encodePacked(requiredPrefix, nonce, amount, expiry, this));
+        require(ecrecover(message, v, r, s) == approvedSigner);
+        //price is signed as szabo units 
+        reciever.transfer(amount * (1 szabo));
+    }
+    
+    function checkIfNonceUsed(uint nonce) internal view {
+        for(uint i = 0; i < nonces.length; i++) {
+            if(nonces[i] == nonce) {
+                revert();
+            }
+        }
+    }
+    
+    function withdraw(uint value) public {
+        require(msg.sender == approvedSigner);
+        approvedSigner.transfer(value);
+    }
+    
+}


### PR DESCRIPTION
This PR creates a contract which enables for magic link drops of native currency like Ether or xDAI. 

Edit: aa72834 working on ropsten

@zhangzhongnan928 ready to move forward with DAI technical team, have this sample contract, payment master sample (either the old one or the new JS one, depends on requirements from them), iOS sample working: https://github.com/AlphaWallet/alpha-wallet-ios/pull/1053 and an amendment to Peter's tool which generates magic links for this: https://github.com/lyhistory/Peter-s-Tool/pull/18