### PR TITLE
log signature to prevent reuse of magic links

### DIFF
--- a/spawnable-contract/schema1/MeetupContract.sol
+++ b/spawnable-contract/schema1/MeetupContract.sol
@@ -193,6 +193,8 @@ contract Meetup
                 spawnedTickets.push(tickets[i]);
             }
         }
+        //prevent link being reused.
+        signatureChecked[s] == true;
     }
 
 	//check if a spawnable ticket that created in a magic link is redeemed


### PR DESCRIPTION
For #114 

@zhangzhongnan928 we can change it to only allow one address claim one magic link but allow the same link to be claimed by different addresses, this may be easier for the ticket organiser, let me know your judgement on this. 

TODO: update factory